### PR TITLE
fix(navbar): align mobile menu and lock scroll

### DIFF
--- a/src/components/Navbar/MobileMenu.jsx
+++ b/src/components/Navbar/MobileMenu.jsx
@@ -22,80 +22,94 @@ const MobileMenu = ({
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: "auto" }}
-          exit={{ opacity: 0, height: 0 }}
-          className="md:hidden border-t border-border bg-background/95 backdrop-blur-xl"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          className="md:hidden fixed inset-0 z-40"
         >
-          <nav className="p-4 space-y-2">
-            {user ? (
-              <>
-                <p className="text-xs font-light text-muted-foreground uppercase tracking-wider px-2 mb-2">Create</p>
-                {createMenuItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    onClick={() => setIsOpen(false)}
-                    className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors font-light ${
-                      isActiveLink(item.href) ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                    }`}
-                  >
-                    <item.icon className="h-5 w-5" />
-                    {item.label}
-                  </Link>
-                ))}
+          <button
+            type="button"
+            aria-label="Close menu"
+            onClick={() => setIsOpen(false)}
+            className="absolute inset-0 bg-black/40"
+          />
+          <motion.div
+            initial={{ x: "100%" }}
+            animate={{ x: 0 }}
+            exit={{ x: "100%" }}
+            transition={{ type: "tween", duration: 0.25 }}
+            className="absolute right-0 top-16 bottom-0 w-[85%] max-w-sm border-l border-border bg-background/95 backdrop-blur-xl overflow-y-auto"
+          >
+            <nav className="p-4 space-y-2">
+              {user ? (
+                <>
+                  <p className="text-xs font-light text-muted-foreground uppercase tracking-wider px-2 mb-2">Create</p>
+                  {createMenuItems.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setIsOpen(false)}
+                      className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors font-light ${
+                        isActiveLink(item.href) ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      }`}
+                    >
+                      <item.icon className="h-5 w-5" />
+                      {item.label}
+                    </Link>
+                  ))}
 
-                <p className="text-xs font-light text-muted-foreground uppercase tracking-wider px-2 mb-2 mt-4">Learn</p>
-                {learnMenuItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    onClick={() => setIsOpen(false)}
-                    className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors font-light ${
-                      isActiveLink(item.href) ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                    }`}
-                  >
-                    <item.icon className="h-5 w-5" />
-                    {item.label}
-                  </Link>
-                ))}
+                  <p className="text-xs font-light text-muted-foreground uppercase tracking-wider px-2 mb-2 mt-4">Learn</p>
+                  {learnMenuItems.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setIsOpen(false)}
+                      className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors font-light ${
+                        isActiveLink(item.href) ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      }`}
+                    >
+                      <item.icon className="h-5 w-5" />
+                      {item.label}
+                    </Link>
+                  ))}
 
-                <p className="text-xs font-light text-muted-foreground uppercase tracking-wider px-2 mb-2 mt-4">More</p>
-                {moreMenuItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
-                    onClick={() => setIsOpen(false)}
-                    className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors font-light ${
-                      isActiveLink(item.href) ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                    }`}
-                  >
-                    <item.icon className="h-5 w-5" />
-                    {item.label}
-                  </Link>
-                ))}
-              </>
-            ) : (
-              <>
-                {landingNavItems.map((item) => (
-                  <button
-                    key={item.id || item.href}
-                    onClick={() => {
-                      setIsOpen(false);
-                      if (item.id) {
-                        document.getElementById(item.id)?.scrollIntoView({ behavior: "smooth" });
-                      } else if (item.href) {
-                        router.push(item.href);
-                      }
-                    }}
-                    className="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground w-full text-left font-light"
-                  >
-                    {item.label}
-                  </button>
-                ))}
-              </>
-            )}
-          </nav>
+                  <p className="text-xs font-light text-muted-foreground uppercase tracking-wider px-2 mb-2 mt-4">More</p>
+                  {moreMenuItems.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setIsOpen(false)}
+                      className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors font-light ${
+                        isActiveLink(item.href) ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                      }`}
+                    >
+                      <item.icon className="h-5 w-5" />
+                      {item.label}
+                    </Link>
+                  ))}
+                </>
+              ) : (
+                <>
+                  {landingNavItems.map((item) => (
+                    <button
+                      key={item.id || item.href}
+                      onClick={() => {
+                        setIsOpen(false);
+                        if (item.id) {
+                          document.getElementById(item.id)?.scrollIntoView({ behavior: "smooth" });
+                        } else if (item.href) {
+                          router.push(item.href);
+                        }
+                      }}
+                      className="flex items-center gap-3 px-3 py-2 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground w-full text-left font-light"
+                    >
+                      {item.label}
+                    </button>
+                  ))}
+                </>
+              )}
+            </nav>
+          </motion.div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -54,6 +54,23 @@ const Navbar = () => {
     document.documentElement.className = savedTheme;
   }, []);
 
+  useEffect(() => {
+    if (!mobileMenuOpen) {
+      return undefined;
+    }
+
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalHtmlOverflow = document.documentElement.style.overflow;
+
+    document.body.style.overflow = "hidden";
+    document.documentElement.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.documentElement.style.overflow = originalHtmlOverflow;
+    };
+  }, [mobileMenuOpen]);
+
   const toggleTheme = () => {
     const newTheme = theme === "light" ? "dark" : "light";
     setTheme(newTheme);
@@ -128,8 +145,9 @@ const Navbar = () => {
   ];
 
   return (
-    <header className="h-16 w-full border-b fixed top-0 left-0 bg-background/80 backdrop-blur-xl z-50 border-border">
-      <div className="h-full max-w-7xl mx-auto px-3 sm:px-4 md:px-6 flex items-center justify-between">
+    <>
+      <header className="h-16 w-full border-b fixed top-0 left-0 bg-background/80 backdrop-blur-xl z-50 border-border">
+        <div className="h-full max-w-7xl mx-auto px-3 sm:px-4 md:px-6 flex items-center justify-between">
         {/* Logo - Left */}
         <Link
           href={user ? `/roadmap` : "/"}
@@ -258,7 +276,8 @@ const Navbar = () => {
             {mobileMenuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
           </Button>
         </div>
-      </div>
+        </div>
+      </header>
 
       {/* Mobile Menu */}
       <MobileMenu
@@ -271,7 +290,7 @@ const Navbar = () => {
         landingNavItems={landingNavItems}
         isActiveLink={isActiveLink}
       />
-    </header>
+    </>
   );
 };
 


### PR DESCRIPTION
## Description
Fix mobile navbar behavior by aligning the slide-in menu with the right-side
hamburger trigger and locking background scroll while the menu is open.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues
Closes #46 

## Screenshots (if applicable)
[
<img width="1920" height="1080" alt="sc-innovision" src="https://github.com/user-attachments/assets/3c0afaf9-5103-47e0-bf77-af68917772d6" />
]

## Testing
- Manual: mobile hamburger menu opens from the right
- Manual: background scroll is locked while menu is open
- Manual: menu closes and scroll is restored

## Checklist
- [x] Code follows style guidelines
- [x] Self-reviewed the code
- [ ] Commented complex code
- [ ] Updated documentation
- [x] No new warnings
- [x] Tested on multiple browsers