### PR TITLE
feat: Add course progress percentage display (#95)

### DIFF
--- a/src/app/roadmap/page.jsx
+++ b/src/app/roadmap/page.jsx
@@ -64,7 +64,7 @@ export default function page() {
                             .map((_, i) => (
                                 <Skeleton
                                     key={i}
-                                    className="w-[320px] h-[240px] rounded-xl"
+                                    className="w-[320px] h-[280px] rounded-xl"
                                 />
                             ))
                     ) : error ? (
@@ -117,7 +117,7 @@ export default function page() {
                             {/* Create New Course Card */}
                             <ScrollReveal delay={completedCourses.length * 50}>
                                 <HoverCard>
-                                    <Card className="w-[320px] h-[240px] relative flex items-center justify-center border-2 border-dashed border-border/50 bg-card/30 backdrop-blur-sm hover:border-blue-500/50 transition-colors">
+                                    <Card className="w-[320px] h-[280px] relative flex items-center justify-center border-2 border-dashed border-border/50 bg-card/30 backdrop-blur-sm hover:border-blue-500/50 transition-colors">
                                         <div className="flex flex-col items-center text-muted-foreground">
                                             <div className="w-16 h-16 rounded-full bg-blue-500/10 flex items-center justify-center mb-3">
                                                 <Plus strokeWidth={1.5} className="w-8 h-8 text-blue-500" />

--- a/src/components/Home/CourseCard.jsx
+++ b/src/components/Home/CourseCard.jsx
@@ -2,15 +2,34 @@
 
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Clock, BookOpen, Trash2 } from "lucide-react";
+import { Clock, BookOpen, Trash2, CheckCircle2 } from "lucide-react";
 import { calculateEstimatedTime } from "@/lib/time-utils";
+import { Progress } from "@/components/ui/progress";
 import DeleteRoadmap from "./DeleteRoadmap";
 
 const CourseCard = ({ course, onDelete }) => {
-  const { id, courseTitle, courseDescription, chapterCount, difficulty } = course;
+  const { id, courseTitle, courseDescription, chapterCount, difficulty, chapters } = course;
+
+  // Calculate progress percentage
+  const calculateProgress = () => {
+    if (!chapters || chapters.length === 0) return 0;
+    const completedChapters = chapters.filter(ch => ch.completed).length;
+    return Math.round((completedChapters / chapters.length) * 100);
+  };
+
+  const progress = calculateProgress();
+  const completedChapters = chapters?.filter(ch => ch.completed).length || 0;
 
   // Calculate estimated time
   const estimatedTime = calculateEstimatedTime(chapterCount, difficulty);
+
+  // Get progress color based on percentage
+  const getProgressColor = (percentage) => {
+    if (percentage === 0) return "bg-gray-400";
+    if (percentage < 33) return "bg-red-500";
+    if (percentage < 67) return "bg-yellow-500";
+    return "bg-green-500";
+  };
 
   // Get difficulty badge color
   const getDifficultyColor = (diff) => {
@@ -40,7 +59,7 @@ const CourseCard = ({ course, onDelete }) => {
   };
 
   return (
-    <Card className="w-[320px] h-[240px] relative group hover:shadow-lg transition-all duration-300 hover:border-blue-500/50 bg-card/50 backdrop-blur-sm">
+    <Card className="w-[320px] h-[280px] relative group hover:shadow-lg transition-all duration-300 hover:border-blue-500/50 bg-card/50 backdrop-blur-sm">
       <Link href={`/roadmap/${id}`} className="absolute inset-0 z-0" />
       
       <CardHeader className="pb-3">
@@ -60,18 +79,41 @@ const CourseCard = ({ course, onDelete }) => {
       </CardHeader>
 
       <CardContent className="space-y-3">
-        {/* Chapter Count */}
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <BookOpen className="h-4 w-4" />
-          <span>
-            {chapterCount} {chapterCount === 1 ? "Chapter" : "Chapters"}
-          </span>
+        {/* Progress Bar */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <div className="flex items-center gap-1.5">
+              <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Progress</span>
+            </div>
+            <span className={`font-semibold ${
+              progress === 100 ? 'text-green-600 dark:text-green-400' : 
+              progress > 0 ? 'text-blue-600 dark:text-blue-400' : 
+              'text-muted-foreground'
+            }`}>
+              {progress}%
+            </span>
+          </div>
+          <Progress 
+            value={progress} 
+            className="h-2"
+            indicatorClassName={getProgressColor(progress)}
+          />
+          <p className="text-xs text-muted-foreground">
+            {completedChapters} of {chapterCount} chapters completed
+          </p>
         </div>
 
-        {/* Estimated Time */}
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Clock className="h-4 w-4" />
-          <span>{estimatedTime}</span>
+        {/* Chapter Count & Time */}
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <BookOpen className="h-4 w-4" />
+            <span>{chapterCount} {chapterCount === 1 ? "Chapter" : "Chapters"}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Clock className="h-4 w-4" />
+            <span>{estimatedTime}</span>
+          </div>
         </div>
 
         {/* Difficulty Badge */}
@@ -83,6 +125,11 @@ const CourseCard = ({ course, onDelete }) => {
           >
             {getDifficultyLabel(difficulty)}
           </span>
+          {progress === 100 && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20">
+              ✓ Completed
+            </span>
+          )}
         </div>
       </CardContent>
     </Card>


### PR DESCRIPTION
Course cards now feature:

- Progress bar with percentage, calculated from completed chapters.
- Color-coded progress (red/yellow/green).
- Display of completed chapter count.
- "Completed" badge for courses with 100% progress.
- Adjusted card height to accommodate the progress bar.
- Responsive design maintained.

Fixes #95

## Before
<img width="943" height="411" alt="image" src="https://github.com/user-attachments/assets/48e6ab39-ded6-4bc6-b9f0-9be8735c298e" />

## Now
### When the course is just enrolled
<img width="1155" height="455" alt="image" src="https://github.com/user-attachments/assets/3c99881c-d7b6-4120-b77f-57d6d4b16f1b" />

### When some progress is made /Goes up to 100%
<img width="1018" height="472" alt="image" src="https://github.com/user-attachments/assets/f5c9c139-f69b-4560-b22d-99f835ae8638" />