### PR TITLE
Fix content rendering crash by adding safety checks for non-string an…

### DIFF
--- a/src/components/MarkDown.jsx
+++ b/src/components/MarkDown.jsx
@@ -224,7 +224,7 @@ const MarkDown = ({ content }) => {
         },
       }}
     >
-      {content}
+      {content || ""}
     </ReactMarkdown>
   );
 };


### PR DESCRIPTION
### Description
This PR addresses client-side crashes that occurred when the AI returned malformed content (non-string or null) for the 'para' type in chapters.

### Key Changes
- Modified [src/components/chapter_content/Content.jsx](file:///c:/Users/visha/Downloads/Innovision-Open-Source/src/components/chapter_content/Content.jsx) to safely handle `item.content` using type checking and array joining.
- Updated [src/components/MarkDown.jsx](file:///c:/Users/visha/Downloads/Innovision-Open-Source/src/components/MarkDown.jsx) to ensure `content` is always a string by providing a default empty string.

### Verification Plan
- Verified that the application no longer crashes when rendering chapters with unexpected content formats.
closes #140 