### PR TITLE
fix: Add bookmark functionality to courses, studio-course, and youtube-course pages (#67)

### DIFF
--- a/src/app/api/bookmarks/route.js
+++ b/src/app/api/bookmarks/route.js
@@ -91,6 +91,12 @@ export async function POST(request) {
         }
       } else if (type === "youtube") {
         notifLink = `/youtube-course/${id}`;
+      } else if (type === "studio") {
+        if (chapterNumber && chapterNumber !== 0) {
+          notifLink = `/studio-course/${id}/${chapterNumber}`;
+        } else {
+          notifLink = `/courses/${id}`;
+        }
       } else {
         if (chapterNumber && chapterNumber !== 0) {
           notifLink = `/chapter-test/${id}/${chapterNumber}`;

--- a/src/app/courses/[id]/page.jsx
+++ b/src/app/courses/[id]/page.jsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { BookOpen, Clock, User, ArrowLeft, Play } from "lucide-react";
 import { toast } from "sonner";
 import ChatBot from "@/components/chat/ChatBot";
+import BookmarkButton from "@/components/chapter_content/BookmarkButton";
 
 export default function CourseDetailPage() {
   const params = useParams();
@@ -91,6 +92,12 @@ export default function CourseDetailPage() {
               <h1 className="text-4xl font-bold mb-2">{course.title}</h1>
               <p className="text-lg text-muted-foreground">{course.description}</p>
             </div>
+            <BookmarkButton
+              courseId={params.id}
+              courseTitle={course.title}
+              courseType="studio"
+              size="lg"
+            />
             <Badge className="ml-4">Published</Badge>
           </div>
 
@@ -145,7 +152,15 @@ export default function CourseDetailPage() {
                       <span className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400 text-sm font-bold">
                         {index + 1}
                       </span>
-                      {chapter.title || `Chapter ${index + 1}`}
+                      <span className="flex-1">{chapter.title || `Chapter ${index + 1}`}</span>
+                      <BookmarkButton
+                        courseId={params.id}
+                        chapterNumber={index + 1}
+                        chapterTitle={chapter.title || `Chapter ${index + 1}`}
+                        courseTitle={course.title}
+                        courseType="studio"
+                        size="sm"
+                      />
                     </CardTitle>
                     {chapter.description && (
                       <CardDescription>{chapter.description}</CardDescription>

--- a/src/app/studio-course/[courseId]/[chapterId]/page.jsx
+++ b/src/app/studio-course/[courseId]/[chapterId]/page.jsx
@@ -9,6 +9,7 @@ import xpContext from "@/contexts/xp";
 import { Button } from "@/components/ui/button";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 import ChatBot from "@/components/chat/ChatBot";
+import BookmarkButton from "@/components/chapter_content/BookmarkButton";
 
 export default function StudioCoursePage() {
   const params = useParams();
@@ -106,6 +107,16 @@ export default function StudioCoursePage() {
       />
       <div className="flex-1 pt-20 lg:ml-96">
         <div className="p-6 max-w-4xl mx-auto">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-2xl font-bold">{currentChapter.title || `Chapter ${chapterIndex + 1}`}</h2>
+            <BookmarkButton
+              courseId={params.courseId}
+              chapterNumber={chapterIndex + 1}
+              chapterTitle={currentChapter.title || `Chapter ${chapterIndex + 1}`}
+              courseTitle={courseData.title}
+              courseType="studio"
+            />
+          </div>
           <StudioContent content={currentChapter.content} />
 
           {/* Chapter Navigation Buttons */}

--- a/src/app/youtube-course/[id]/page.jsx
+++ b/src/app/youtube-course/[id]/page.jsx
@@ -17,6 +17,7 @@ import { useAuth } from "@/contexts/auth";
 import MarkDown from "@/components/MarkDown";
 import { getOfflineCourses } from "@/lib/offline";
 import ChatBot from "@/components/chat/ChatBot";
+import BookmarkButton from "@/components/chapter_content/BookmarkButton";
 
 export default function YouTubeCourseView() {
   const params = useParams();
@@ -349,15 +350,24 @@ export default function YouTubeCourseView() {
                           {activeChapter.description}
                         </CardDescription>
                       </div>
-                      {completedChapters.includes(activeChapter.number) ? (
-                        <Button variant="outline" onClick={() => markChapterComplete(activeChapter.number, false)}>
-                          <CheckCircle2 className="h-4 w-4 mr-2" /> Completed
-                        </Button>
-                      ) : (
-                        <Button onClick={() => markChapterComplete(activeChapter.number, true)}>
-                          <CheckCircle className="h-4 w-4 mr-2" /> Mark Complete
-                        </Button>
-                      )}
+                      <div className="flex items-center gap-2">
+                        <BookmarkButton
+                          courseId={params.id}
+                          chapterNumber={activeChapter.number}
+                          chapterTitle={activeChapter.title || `Chapter ${activeChapter.number}`}
+                          courseTitle={course.title}
+                          courseType="youtube"
+                        />
+                        {completedChapters.includes(activeChapter.number) ? (
+                          <Button variant="outline" onClick={() => markChapterComplete(activeChapter.number, false)}>
+                            <CheckCircle2 className="h-4 w-4 mr-2" /> Completed
+                          </Button>
+                        ) : (
+                          <Button onClick={() => markChapterComplete(activeChapter.number, true)}>
+                            <CheckCircle className="h-4 w-4 mr-2" /> Mark Complete
+                          </Button>
+                        )}
+                      </div>
                     </div>
                   </CardHeader>
                 </Card>

--- a/src/components/profile/Bookmarks.jsx
+++ b/src/components/profile/Bookmarks.jsx
@@ -35,7 +35,9 @@ export default function Bookmarks() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           roadmapId: bookmark.roadmapId,
+          courseId: bookmark.courseId || bookmark.roadmapId,
           chapterNumber: bookmark.chapterNumber,
+          courseType: bookmark.courseType || "roadmap",
           action: "remove",
         }),
       });
@@ -65,6 +67,12 @@ export default function Bookmarks() {
       }
     } else if (type === "youtube") {
       router.push(`/youtube-course/${id}`);
+    } else if (type === "studio") {
+      if (chapter && chapter !== 0) {
+        router.push(`/studio-course/${id}/${chapter}`);
+      } else {
+        router.push(`/courses/${id}`);
+      }
     } else {
       // Default to roadmap pattern
       if (chapter && chapter !== 0) {


### PR DESCRIPTION
## Summary

Fixes #67 — Bookmarks were not getting added under the courses section.

## Problem

The \BookmarkButton\ component existed but was only used in roadmap (\chapter_content\) and ingested-course pages. It was **missing** from:
- \courses/[id]/page.jsx\ (Studio course detail/overview)
- \studio-course/[courseId]/[chapterId]/page.jsx\ (Studio course chapter view)
- \youtube-course/[id]/page.jsx\ (YouTube course chapter view)

Additionally, the bookmarks API and profile Bookmarks component had no handling for the \studio\ course type, causing broken navigation links.

## Changes

### BookmarkButton added to course pages
- **\src/app/courses/[id]/page.jsx\** — Added course-level bookmark in the header + per-chapter bookmark buttons in the chapter list
- **\src/app/studio-course/[courseId]/[chapterId]/page.jsx\** — Added bookmark button in the chapter header area
- **\src/app/youtube-course/[id]/page.jsx\** — Added bookmark button next to the Mark Complete button in the chapter header

### API & navigation fixes
- **\src/app/api/bookmarks/route.js\** — Added \studio\ courseType handling for notification links (\/studio-course/{id}/{chapter}\ or \/courses/{id}\)
- **\src/components/profile/Bookmarks.jsx\** — Added \studio\ courseType navigation in \goToChapter()\, and fixed \emoveBookmark()\ to pass \courseId\ and \courseType\ for correct bookmark ID matching

## Testing
1. Navigate to any Studio course (\/courses/{id}\) — bookmark icon appears in header and on each chapter card
2. Open a Studio chapter (\/studio-course/{id}/{chapter}\) — bookmark icon appears next to chapter title
3. Open a YouTube course chapter — bookmark icon appears next to the completion button
4. Verify bookmarks appear in profile and clicking them navigates correctly
5. Verify removing bookmarks from profile works for all course types