### PR TITLE
fix: Polish course archiving feature - fix bugs and add missing functionality (#104)

### DIFF
--- a/src/app/roadmap/page.jsx
+++ b/src/app/roadmap/page.jsx
@@ -95,15 +95,8 @@ export default function page() {
 
     const completedCourses = roadmaps.filter(r => r.process === "completed");
 
-    // Filter by archive status
-    const statusFilteredCourses = completedCourses.filter((course) => {
-        if (archiveFilter === "active") return !course.archived;
-        if (archiveFilter === "archived") return course.archived;
-        return true; // "all"
-    });
-
     // Filter and sort courses
-    const filteredCourses = statusFilteredCourses
+    const filteredCourses = completedCourses
         .filter((course) => {
             // Archive filter - treat undefined/null as not archived
             const isArchived = course.archived === true;
@@ -363,18 +356,6 @@ export default function page() {
                                     <SelectItem value="fast">Fast-paced</SelectItem>
                                     <SelectItem value="balanced">Balanced</SelectItem>
                                     <SelectItem value="in-depth">In-depth</SelectItem>
-                                </SelectContent>
-                            </Select>
-
-                            {/* Archive Filter */}
-                            <Select value={archiveFilter} onValueChange={setArchiveFilter}>
-                                <SelectTrigger className="w-35 h-9 bg-card/50 backdrop-blur-sm border-border/50">
-                                    <SelectValue placeholder="Status" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="active">Active</SelectItem>
-                                    <SelectItem value="archived">Archived</SelectItem>
-                                    <SelectItem value="all">All Courses</SelectItem>
                                 </SelectContent>
                             </Select>
 

--- a/src/components/Home/CourseCard.jsx
+++ b/src/components/Home/CourseCard.jsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Clock, BookOpen, CheckCircle2 } from "lucide-react";
+import { Clock, BookOpen, CheckCircle2, Archive } from "lucide-react";
 import { calculateEstimatedTime } from "@/lib/time-utils";
 import { Progress } from "@/components/ui/progress";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -164,6 +164,11 @@ const CourseCard = ({ course, onDelete, onArchive, isSelectable, isSelected, onS
           {progress === 100 && (
             <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium border bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20">
               ✓ Completed
+            </span>
+          )}
+          {archived && (
+            <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium border bg-orange-500/10 text-orange-600 dark:text-orange-400 border-orange-500/20">
+              <Archive className="h-3 w-3" /> Archived
             </span>
           )}
         </div>

--- a/src/lib/premium.js
+++ b/src/lib/premium.js
@@ -153,7 +153,9 @@ export async function getUserCourseCount(userEmail) {
       .where("process", "==", "completed")
       .get();
 
-    return snapshot.size;
+    // Exclude archived courses from the count so they don't count toward limits
+    const activeCourses = snapshot.docs.filter(doc => !doc.data().archived);
+    return activeCourses.length;
   } catch (error) {
     console.error("Error getting course count:", error);
     return 0;


### PR DESCRIPTION
## Summary

Addresses remaining issues in the course archiving feature (#104). The core archiving functionality (ArchiveCourse component, archive API, bulk actions, filter UI) was already implemented, but had several bugs and missing pieces from the acceptance criteria.

## Bugs Fixed

### 1. Duplicate Archive Filter Dropdown
The filters row in `roadmap/page.jsx` had **two identical** archive status `<Select>` dropdowns rendered side-by-side. Removed the duplicate.

### 2. Double Archive Filtering Logic
Courses were being filtered by archive status **twice**:
- First via `statusFilteredCourses` (filtered `completedCourses` by archive)
- Then via `filteredCourses` (filtered `statusFilteredCourses` by archive again)

Consolidated into a single clean filter pass.

### 3. Archived Courses Counted Toward Course Limit
`getUserCourseCount()` in `src/lib/premium.js` counted all completed roadmaps including archived ones. This meant archiving a course still counted against the free tier's 3-course limit, defeating the purpose of archiving. Now excludes archived courses from the count.

**From acceptance criteria:** *"Archive doesn't count toward course limit"*

## Features Added

### 4. Visual "Archived" Badge on Course Cards
Archived courses had no visual indicator when viewed in the "All" or "Archived" filter. Added an orange "Archived" badge (with Archive icon) next to the difficulty badge on `CourseCard`.

## Files Changed

| File | Change |
|------|--------|
| `src/app/roadmap/page.jsx` | Removed duplicate archive filter, consolidated double filtering |
| `src/components/Home/CourseCard.jsx` | Added "Archived" badge with Archive icon |
| `src/lib/premium.js` | Excluded archived courses from `getUserCourseCount()` |

## Testing
1. Navigate to `/roadmap` - only one archive status filter dropdown appears
2. Switch between Active/Archived/All - filtering works correctly in one pass
3. Archive a course - orange "Archived" badge visible on the card
4. With 3 courses (free tier), archive one - can now create a new course (archived does not count)
5. Unarchive - badge disappears, counts toward limit again
