### PR TITLE
fix: Night Mode and Base Theme State Desynchronization (#112)

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -82,12 +82,21 @@ const Navbar = () => {
     const newTheme = theme === "light" ? "dark" : "light";
     setTheme(newTheme);
     localStorage.setItem("theme", newTheme);
+
+    // Preserve night-mode class across theme switches
+    const hasNightMode = document.documentElement.classList.contains("night-mode");
+
     if (newTheme === "dark") {
       document.documentElement.classList.add("dark");
       document.documentElement.classList.remove("light");
     } else {
       document.documentElement.classList.add("light");
       document.documentElement.classList.remove("dark");
+    }
+
+    // Re-apply night-mode if it was (or should be) active
+    if (hasNightMode || nightMode) {
+      document.documentElement.classList.add("night-mode");
     }
   };
 

--- a/src/contexts/nightMode.jsx
+++ b/src/contexts/nightMode.jsx
@@ -1,32 +1,58 @@
 "use client";
 
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext, useState, useEffect, useCallback } from "react";
 
 const NightModeContext = createContext();
 
 export function NightModeProvider({ children }) {
   const [nightMode, setNightMode] = useState(false);
 
+  // Apply or remove the night-mode class on the DOM
+  const applyNightMode = useCallback((enabled) => {
+    if (enabled) {
+      document.documentElement.classList.add("night-mode");
+    } else {
+      document.documentElement.classList.remove("night-mode");
+    }
+  }, []);
+
   // Load saved night mode preference
   useEffect(() => {
     const saved = localStorage.getItem("nightMode");
     if (saved === "true") {
       setNightMode(true);
-      document.documentElement.classList.add("night-mode");
+      applyNightMode(true);
     }
-  }, []);
+  }, [applyNightMode]);
 
-  const toggleNightMode = () => {
-    const newValue = !nightMode;
-    setNightMode(newValue);
-    localStorage.setItem("nightMode", String(newValue));
+  // Watch for theme class changes (light ↔ dark) on <html>.
+  // When the theme is toggled, classList operations may briefly remove night-mode
+  // or the re-render may cause the class to be missing. This observer re-applies it.
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const hasNightClass = document.documentElement.classList.contains("night-mode");
+      if (nightMode && !hasNightClass) {
+        // Night mode is enabled in state but missing from DOM — re-apply it
+        document.documentElement.classList.add("night-mode");
+      }
+    });
 
-    if (newValue) {
-      document.documentElement.classList.add("night-mode");
-    } else {
-      document.documentElement.classList.remove("night-mode");
-    }
-  };
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => observer.disconnect();
+  }, [nightMode]);
+
+  const toggleNightMode = useCallback(() => {
+    setNightMode((prev) => {
+      const newValue = !prev;
+      localStorage.setItem("nightMode", String(newValue));
+      applyNightMode(newValue);
+      return newValue;
+    });
+  }, [applyNightMode]);
 
   return (
     <NightModeContext.Provider value={{ nightMode, toggleNightMode }}>


### PR DESCRIPTION
## Fix Night Mode and Theme State Desynchronization

Closes #112

### Problem

Night Mode becomes non-functional after switching between Light and Dark themes. The root cause is that the theme toggle (`light` ↔ `dark` class on `<html>`) and Night Mode (`night-mode` class on `<html>`) are managed as completely independent state — neither is aware of the other. When the theme is toggled, the `night-mode` CSS filter class can get lost or become visually inconsistent.

### Fix

**`src/contexts/nightMode.jsx`**
- Added a `MutationObserver` on the `<html>` element's `class` attribute. When the theme toggle modifies classes and `night-mode` gets removed or lost, the observer immediately re-applies it if night mode is enabled in React state
- Extracted `applyNightMode()` helper with `useCallback` for consistent DOM manipulation
- Used functional state update in `toggleNightMode` to prevent stale closure issues

**`src/components/Navbar/Navbar.jsx`**
- Updated `toggleTheme()` to explicitly check for and preserve the `night-mode` class after switching between `dark` and `light` classes
- Checks both the DOM class (`classList.contains`) and React state (`nightMode`) to handle edge cases

### How to Test

1. Enable Night Mode (warm filter appears)
2. Switch from Light → Dark theme → Night Mode filter persists correctly
3. Switch from Dark → Light theme → Night Mode filter still works
4. Toggle Night Mode off → filter disappears as expected
5. All combinations of theme + night mode work consistently
