### PR TITLE
fix: Desynchronized Offline State and Conflict Resolution (#180)

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,5 +1,5 @@
-// Service Worker for Offline Support
-const CACHE_NAME = 'innovision-v1';
+// Service Worker for Offline Support with Background Sync
+const CACHE_NAME = 'innovision-v2';
 const urlsToCache = [
   '/',
   '/roadmap',
@@ -12,13 +12,36 @@ self.addEventListener('install', (event) => {
     caches.open(CACHE_NAME)
       .then((cache) => cache.addAll(urlsToCache))
   );
+  // Activate immediately
+  self.skipWaiting();
 });
 
 self.addEventListener('fetch', (event) => {
+  // Don't cache API requests
+  if (event.request.url.includes('/api/')) {
+    event.respondWith(
+      fetch(event.request).catch(() => {
+        return new Response(
+          JSON.stringify({ error: 'Offline', offline: true }),
+          { status: 503, headers: { 'Content-Type': 'application/json' } }
+        );
+      })
+    );
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request)
       .then((response) => {
         if (response) {
+          // Return cached response and update cache in background
+          fetch(event.request).then((freshResponse) => {
+            if (freshResponse && freshResponse.status === 200) {
+              caches.open(CACHE_NAME).then((cache) => {
+                cache.put(event.request, freshResponse);
+              });
+            }
+          }).catch(() => {});
           return response;
         }
         return fetch(event.request).then((response) => {
@@ -49,6 +72,109 @@ self.addEventListener('activate', (event) => {
           }
         })
       );
-    })
+    }).then(() => self.clients.claim())
   );
 });
+
+// Background Sync — triggered when connectivity is restored
+self.addEventListener('sync', (event) => {
+  if (event.tag === 'sync-progress') {
+    event.waitUntil(syncOfflineProgress());
+  }
+});
+
+/**
+ * Background sync: read unsynced progress from IndexedDB and POST to server.
+ * Uses the same IndexedDB structure as the client-side offline.js.
+ */
+async function syncOfflineProgress() {
+  try {
+    const db = await openIndexedDB();
+    const tx = db.transaction('progress', 'readonly');
+    const index = tx.objectStore('progress').index('synced');
+    const request = index.getAll(0);
+
+    const unsyncedItems = await idbRequestToPromise(request);
+    await tx.done;
+
+    if (!unsyncedItems || unsyncedItems.length === 0) return;
+
+    // Group by courseId
+    const grouped = {};
+    for (const item of unsyncedItems) {
+      const key = item.courseId;
+      if (!key) continue;
+      if (!grouped[key]) {
+        grouped[key] = { courseId: item.courseId, courseType: item.courseType || 'roadmap', chapters: {}, ids: [] };
+      }
+      const chapterKey = item.chapter || item.chapterKey || 'unknown';
+      grouped[key].chapters[chapterKey] = {
+        completed: item.completed || false,
+        completedAt: item.timestamp || Date.now(),
+        timeSpent: item.timeSpent || 0,
+      };
+      grouped[key].ids.push(item.id);
+    }
+
+    for (const [, group] of Object.entries(grouped)) {
+      try {
+        const response = await fetch('/api/progress/sync', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            courseId: group.courseId,
+            courseType: group.courseType,
+            chapters: group.chapters,
+            clientTimestamp: Date.now(),
+          }),
+        });
+
+        if (response.ok) {
+          // Mark synced
+          const writeTx = db.transaction('progress', 'readwrite');
+          const store = writeTx.objectStore('progress');
+          for (const id of group.ids) {
+            const record = await idbRequestToPromise(store.get(id));
+            if (record) {
+              record.synced = 1;
+              store.put(record);
+            }
+          }
+          await writeTx.done;
+        }
+      } catch {
+        // Will retry on next sync event
+      }
+    }
+  } catch (error) {
+    console.warn('Background sync failed:', error);
+  }
+}
+
+/**
+ * Open IndexedDB from within the service worker (no idb library here)
+ */
+function openIndexedDB() {
+  return new Promise((resolve, reject) => {
+    const request = indexedDB.open('InnoVisionOffline', 2);
+    request.onerror = () => reject(request.error);
+    request.onsuccess = () => resolve(request.result);
+    request.onupgradeneeded = () => {
+      // Let the main thread handle upgrades
+    };
+  });
+}
+
+/**
+ * Convert IDBRequest to a promise
+ */
+function idbRequestToPromise(request) {
+  return new Promise((resolve, reject) => {
+    if (request.readyState === 'done') {
+      resolve(request.result);
+      return;
+    }
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}

--- a/src/app/api/progress/sync/route.js
+++ b/src/app/api/progress/sync/route.js
@@ -1,23 +1,161 @@
-// Progress Sync API for Offline Support
+// Progress Sync API for Offline Support — with LWW merge & server-side validation
 import { NextResponse } from "next/server";
-import { adminDb } from "@/lib/firebase-admin";
+import { getServerSession } from "@/lib/auth-server";
+import { adminDb, FieldValue } from "@/lib/firebase-admin";
 
-export async function POST(request) {
+// Minimum seconds a chapter should take to complete (prevents spoofed instant completions)
+const MIN_CHAPTER_DURATION_SECONDS = 30;
+
+/**
+ * GET /api/progress/sync — fetch server-side progress for a course
+ * Query params: courseId (required), courseType (optional, default "roadmap")
+ */
+export async function GET(request) {
   try {
-    const progress = await request.json();
-
-    if (!progress.userId || !progress.courseId) {
-      return NextResponse.json({ error: "Invalid progress data" }, { status: 400 });
+    const session = await getServerSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    // Save to Firebase
-    const progressRef = adminDb.collection("progress").doc(`${progress.userId}_${progress.courseId}_${Date.now()}`);
-    await progressRef.set({
-      ...progress,
-      syncedAt: Date.now(),
+    const { searchParams } = new URL(request.url);
+    const courseId = searchParams.get("courseId");
+    if (!courseId) {
+      return NextResponse.json({ error: "courseId is required" }, { status: 400 });
+    }
+
+    const email = session.user.email;
+
+    // Fetch the canonical progress doc for this user+course
+    const docId = `${email}_${courseId}`;
+    const docRef = adminDb.collection("progress").doc(docId);
+    const docSnap = await docRef.get();
+
+    if (!docSnap.exists) {
+      return NextResponse.json({
+        progress: null,
+        message: "No server progress found",
+      });
+    }
+
+    return NextResponse.json({ progress: docSnap.data() });
+  } catch (error) {
+    console.error("Progress fetch error:", error);
+    return NextResponse.json({ error: "Failed to fetch progress" }, { status: 500 });
+  }
+}
+
+/**
+ * POST /api/progress/sync — merge offline progress with server state using LWW
+ * Body: { courseId, courseType, chapters: { [chapterKey]: { completed, completedAt, timeSpent } }, clientTimestamp }
+ */
+export async function POST(request) {
+  try {
+    const session = await getServerSession();
+    if (!session) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { courseId, courseType, chapters, clientTimestamp } = body;
+
+    if (!courseId || !chapters || typeof chapters !== "object") {
+      return NextResponse.json(
+        { error: "courseId and chapters object are required" },
+        { status: 400 }
+      );
+    }
+
+    const email = session.user.email;
+    const docId = `${email}_${courseId}`;
+    const docRef = adminDb.collection("progress").doc(docId);
+
+    // Run merge inside a transaction for atomicity
+    const result = await adminDb.runTransaction(async (transaction) => {
+      const docSnap = await transaction.get(docRef);
+      const serverData = docSnap.exists ? docSnap.data() : {};
+      const serverChapters = serverData.chapters || {};
+      const mergedChapters = { ...serverChapters };
+      const conflicts = [];
+      let rejected = 0;
+
+      for (const [chapterKey, clientChapter] of Object.entries(chapters)) {
+        const serverChapter = serverChapters[chapterKey];
+        const clientCompletedAt = clientChapter.completedAt || 0;
+        const serverCompletedAt = serverChapter?.completedAt || 0;
+
+        // Validate: reject suspiciously fast completions (anti-spoofing)
+        if (clientChapter.completed && clientChapter.timeSpent !== undefined) {
+          if (clientChapter.timeSpent < MIN_CHAPTER_DURATION_SECONDS) {
+            conflicts.push({
+              chapter: chapterKey,
+              reason: "completion_too_fast",
+              clientTimeSpent: clientChapter.timeSpent,
+              minimumRequired: MIN_CHAPTER_DURATION_SECONDS,
+            });
+            rejected++;
+            continue; // Skip this chapter — don't merge suspicious data
+          }
+        }
+
+        // LWW merge: keep whichever has the later completedAt timestamp
+        if (!serverChapter) {
+          // No server record — accept client data
+          mergedChapters[chapterKey] = {
+            completed: clientChapter.completed || false,
+            completedAt: clientCompletedAt,
+            timeSpent: clientChapter.timeSpent || 0,
+            source: "offline",
+          };
+        } else if (clientCompletedAt > serverCompletedAt) {
+          // Client is newer — use client data
+          mergedChapters[chapterKey] = {
+            completed: clientChapter.completed || false,
+            completedAt: clientCompletedAt,
+            timeSpent: clientChapter.timeSpent || 0,
+            source: "offline",
+          };
+          if (serverChapter.completed && !clientChapter.completed) {
+            // Conflict: server had it completed but client says not completed (but client is newer)
+            conflicts.push({
+              chapter: chapterKey,
+              reason: "overwrite_completed",
+              resolution: "client_wins_lww",
+            });
+          }
+        } else {
+          // Server is newer or equal — keep server data
+          if (clientChapter.completed && !serverChapter.completed) {
+            conflicts.push({
+              chapter: chapterKey,
+              reason: "server_newer",
+              resolution: "server_wins_lww",
+            });
+          }
+          // Server data already in mergedChapters
+        }
+      }
+
+      const mergedDoc = {
+        userId: email,
+        courseId,
+        courseType: courseType || "roadmap",
+        chapters: mergedChapters,
+        lastSyncedAt: Date.now(),
+        updatedAt: FieldValue.serverTimestamp(),
+      };
+
+      transaction.set(docRef, mergedDoc, { merge: true });
+
+      return { mergedChapters, conflicts, rejected };
     });
 
-    return NextResponse.json({ success: true, message: "Progress synced successfully" });
+    return NextResponse.json({
+      success: true,
+      message: "Progress synced with LWW merge",
+      conflicts: result.conflicts,
+      rejected: result.rejected,
+      chapters: result.mergedChapters,
+    });
   } catch (error) {
     console.error("Progress sync error:", error);
     return NextResponse.json({ error: "Failed to sync progress" }, { status: 500 });

--- a/src/components/OfflineIndicator.jsx
+++ b/src/components/OfflineIndicator.jsx
@@ -1,35 +1,70 @@
 "use client";
 import { useEffect, useState } from "react";
-import { WifiOff, Wifi } from "lucide-react";
-import { setupOfflineListeners, syncOfflineData } from "@/lib/offline";
+import { WifiOff, Wifi, CheckCircle, AlertCircle, RefreshCw } from "lucide-react";
+import { useOffline } from "@/hooks/useOffline";
 
 export default function OfflineIndicator() {
-  const [isOnline, setIsOnline] = useState(true);
-  const [syncing, setSyncing] = useState(false);
+  const { isOnline, isSyncing, syncResult } = useOffline();
+  const [showBanner, setShowBanner] = useState(false);
 
   useEffect(() => {
-    setIsOnline(navigator.onLine);
+    if (!isOnline || isSyncing || syncResult) {
+      setShowBanner(true);
+    }
 
-    setupOfflineListeners(
-      async () => {
-        setIsOnline(true);
-        setSyncing(true);
-        await syncOfflineData();
-        setSyncing(false);
-      },
-      () => {
-        setIsOnline(false);
+    // Auto-hide success banner after a few seconds
+    if (isOnline && !isSyncing && syncResult?.success && syncResult?.synced === 0 && !syncResult?.failed) {
+      const timer = setTimeout(() => setShowBanner(false), 2000);
+      return () => clearTimeout(timer);
+    }
+
+    if (syncResult && !isSyncing) {
+      const timer = setTimeout(() => setShowBanner(false), 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [isOnline, isSyncing, syncResult]);
+
+  // Hide when everything is normal
+  if (isOnline && !isSyncing && !syncResult && !showBanner) return null;
+  if (!showBanner) return null;
+
+  // Determine banner content
+  let bgColor = "bg-red-500";
+  let icon = <WifiOff className="w-4 h-4" />;
+  let message = "Offline mode — changes saved locally";
+
+  if (isOnline && isSyncing) {
+    bgColor = "bg-blue-500";
+    icon = <RefreshCw className="w-4 h-4 animate-spin" />;
+    message = "Syncing offline changes...";
+  } else if (isOnline && syncResult) {
+    if (syncResult.failed > 0) {
+      bgColor = "bg-yellow-500";
+      icon = <AlertCircle className="w-4 h-4" />;
+      message = `Synced ${syncResult.synced}, ${syncResult.failed} failed`;
+      if (syncResult.conflicts?.length > 0) {
+        message += ` (${syncResult.conflicts.length} conflicts resolved)`;
       }
-    );
-  }, []);
-
-  if (isOnline && !syncing) return null;
+    } else if (syncResult.synced > 0) {
+      bgColor = "bg-green-500";
+      icon = <CheckCircle className="w-4 h-4" />;
+      message = `${syncResult.synced} changes synced successfully`;
+      if (syncResult.conflicts?.length > 0) {
+        message += ` (${syncResult.conflicts.length} conflicts resolved)`;
+      }
+    } else {
+      bgColor = "bg-blue-500";
+      icon = <Wifi className="w-4 h-4" />;
+      message = "Back online";
+    }
+  }
 
   return (
-    <div className={`fixed bottom-4 right-4 px-4 py-2 rounded-lg shadow-lg flex items-center gap-2 ${isOnline ? 'bg-blue-500' : 'bg-red-500'
-      } text-white`}>
-      {isOnline ? <Wifi className="w-4 h-4" /> : <WifiOff className="w-4 h-4" />}
-      <span>{syncing ? 'Syncing...' : isOnline ? 'Back online' : 'Offline mode'}</span>
+    <div
+      className={`fixed bottom-4 right-4 px-4 py-2 rounded-lg shadow-lg flex items-center gap-2 z-50 ${bgColor} text-white transition-all duration-300`}
+    >
+      {icon}
+      <span className="text-sm">{message}</span>
     </div>
   );
 }

--- a/src/hooks/useOffline.js
+++ b/src/hooks/useOffline.js
@@ -1,66 +1,121 @@
-// Custom hook for offline functionality
-import { useEffect, useState } from "react";
+// Custom hook for offline functionality with conflict resolution
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   saveCourseOffline,
   getOfflineCourses,
   saveProgressOffline,
-  syncOfflineData
+  syncOfflineData,
+  setupOfflineListeners,
 } from "@/lib/offline";
 
 export function useOffline() {
   const [isOnline, setIsOnline] = useState(true);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const [syncResult, setSyncResult] = useState(null);
   const [offlineCourses, setOfflineCourses] = useState([]);
+  const cleanupRef = useRef(null);
+
+  const loadOfflineCourses = useCallback(async () => {
+    try {
+      const courses = await getOfflineCourses();
+      setOfflineCourses(courses);
+    } catch (error) {
+      console.warn("Failed to load offline courses:", error);
+    }
+  }, []);
+
+  const triggerSync = useCallback(async () => {
+    if (!navigator.onLine) return;
+    setIsSyncing(true);
+    setSyncResult(null);
+    try {
+      const result = await syncOfflineData();
+      setSyncResult(result);
+      // Clear result after 5 seconds
+      setTimeout(() => setSyncResult(null), 5000);
+    } catch (error) {
+      setSyncResult({ success: false, message: error.message, synced: 0, failed: 0 });
+    } finally {
+      setIsSyncing(false);
+    }
+  }, []);
 
   useEffect(() => {
     setIsOnline(navigator.onLine);
     loadOfflineCourses();
 
-    const handleOnline = () => {
-      setIsOnline(true);
-      syncOfflineData();
-    };
-
-    const handleOffline = () => {
-      setIsOnline(false);
-    };
-
-    window.addEventListener('online', handleOnline);
-    window.addEventListener('offline', handleOffline);
+    // Single place for online/offline listeners — no duplicates
+    const cleanup = setupOfflineListeners(
+      () => {
+        setIsOnline(true);
+        triggerSync();
+      },
+      () => {
+        setIsOnline(false);
+      }
+    );
+    cleanupRef.current = cleanup;
 
     return () => {
-      window.removeEventListener('online', handleOnline);
-      window.removeEventListener('offline', handleOffline);
+      if (cleanupRef.current) cleanupRef.current();
     };
-  }, []);
+  }, [loadOfflineCourses, triggerSync]);
 
-  const loadOfflineCourses = async () => {
-    const courses = await getOfflineCourses();
-    setOfflineCourses(courses);
-  };
+  const downloadCourse = useCallback(
+    async (course) => {
+      await saveCourseOffline(course);
+      await loadOfflineCourses();
+    },
+    [loadOfflineCourses]
+  );
 
-  const downloadCourse = async (course) => {
-    await saveCourseOffline(course);
-    await loadOfflineCourses();
-  };
+  const saveProgress = useCallback(
+    async (progress) => {
+      if (isOnline) {
+        // Save to server directly; also store locally for resilience
+        try {
+          const response = await fetch("/api/progress/sync", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              courseId: progress.courseId,
+              courseType: progress.courseType || "roadmap",
+              chapters: {
+                [progress.chapter || progress.chapterKey || "unknown"]: {
+                  completed: progress.completed || false,
+                  completedAt: Date.now(),
+                  timeSpent: progress.timeSpent || 0,
+                },
+              },
+              clientTimestamp: Date.now(),
+            }),
+          });
 
-  const saveProgress = async (progress) => {
-    if (isOnline) {
-      // Save directly to server
-      await fetch('/api/progress/sync', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(progress),
-      });
-    } else {
-      // Save offline for later sync
-      await saveProgressOffline(progress);
-    }
-  };
+          if (!response.ok) {
+            // Server rejected — save offline for later retry
+            await saveProgressOffline(progress);
+          }
+        } catch {
+          // Network error — save offline
+          await saveProgressOffline(progress);
+        }
+      } else {
+        // Offline — save locally for later sync
+        await saveProgressOffline(progress);
+      }
+    },
+    [isOnline]
+  );
 
   return {
     isOnline,
+    isSyncing,
+    syncResult,
     offlineCourses,
     downloadCourse,
     saveProgress,
+    triggerSync,
   };
 }

--- a/src/lib/offline.js
+++ b/src/lib/offline.js
@@ -1,25 +1,44 @@
-// Offline-First Capabilities
+// Offline-First Capabilities with LWW Conflict Resolution
 import { openDB } from "idb";
 
 const DB_NAME = "InnoVisionOffline";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+// Prevent concurrent syncs
+let syncInProgress = false;
 
 /**
  * Initialize IndexedDB for offline storage
  */
 export async function initOfflineDB() {
   return openDB(DB_NAME, DB_VERSION, {
-    upgrade(db) {
+    upgrade(db, oldVersion) {
       // Courses store
       if (!db.objectStoreNames.contains("courses")) {
         db.createObjectStore("courses", { keyPath: "id" });
       }
 
-      // Progress store
+      // Progress store — deduplicated by courseId+chapter
       if (!db.objectStoreNames.contains("progress")) {
-        const progressStore = db.createObjectStore("progress", { keyPath: "id", autoIncrement: true });
+        const progressStore = db.createObjectStore("progress", {
+          keyPath: "id",
+          autoIncrement: true,
+        });
         progressStore.createIndex("synced", "synced");
         progressStore.createIndex("timestamp", "timestamp");
+        progressStore.createIndex("courseId", "courseId");
+      }
+
+      // v2: add courseId index to existing stores
+      if (oldVersion < 2) {
+        if (db.objectStoreNames.contains("progress")) {
+          const tx = db.transaction("progress", "readwrite");
+          if (!tx.store.indexNames.contains("courseId")) {
+            tx.store.createIndex("courseId", "courseId");
+          }
+        }
       }
 
       // Cache store
@@ -50,15 +69,47 @@ export async function getOfflineCourses() {
 }
 
 /**
- * Save progress offline (to sync later)
+ * Save progress offline with deduplication.
+ * If a record for the same courseId + chapter already exists (unsynced),
+ * update it instead of creating a duplicate.
  */
 export async function saveProgressOffline(progress) {
   const db = await initOfflineDB();
-  await db.add("progress", {
-    ...progress,
-    synced: 0,
-    timestamp: Date.now(),
-  });
+
+  // Check for existing unsynced record with same courseId + chapter
+  const allUnsynced = await getUnsyncedProgress();
+  const existing = allUnsynced.find(
+    (p) =>
+      p.courseId === progress.courseId &&
+      p.chapter === progress.chapter
+  );
+
+  if (existing) {
+    // Update existing record with newer data (LWW at client level)
+    const updated = {
+      ...existing,
+      ...progress,
+      timestamp: Date.now(),
+      synced: 0,
+    };
+    await db.put("progress", updated);
+  } else {
+    await db.add("progress", {
+      ...progress,
+      synced: 0,
+      timestamp: Date.now(),
+    });
+  }
+
+  // Request background sync if supported
+  if ("serviceWorker" in navigator && "SyncManager" in window) {
+    try {
+      const registration = await navigator.serviceWorker.ready;
+      await registration.sync.register("sync-progress");
+    } catch {
+      // Background sync not available — will sync on reconnect
+    }
+  }
 }
 
 /**
@@ -84,50 +135,139 @@ export async function markProgressSynced(progressId) {
 }
 
 /**
- * Sync offline data when online
+ * Group unsynced progress entries by courseId for batch sync
  */
-export async function syncOfflineData() {
-  if (!navigator.onLine) {
-    return { success: false, message: "Device is offline" };
-  }
-
-  const unsyncedProgress = await getUnsyncedProgress();
-  const results = [];
-
-  for (const progress of unsyncedProgress) {
-    try {
-      const response = await fetch("/api/progress/sync", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(progress),
-      });
-
-      if (response.ok) {
-        await markProgressSynced(progress.id);
-        results.push({ id: progress.id, success: true });
-      } else {
-        results.push({ id: progress.id, success: false, error: "Sync failed" });
-      }
-    } catch (error) {
-      results.push({ id: progress.id, success: false, error: error.message });
+function groupByCourse(progressEntries) {
+  const grouped = {};
+  for (const entry of progressEntries) {
+    const key = entry.courseId;
+    if (!key) continue;
+    if (!grouped[key]) {
+      grouped[key] = {
+        courseId: entry.courseId,
+        courseType: entry.courseType || "roadmap",
+        chapters: {},
+        ids: [], // track IndexedDB IDs for marking synced
+      };
     }
+    // LWW: if same chapter appears multiple times, keep the newest
+    const chapterKey = entry.chapter || entry.chapterKey || "unknown";
+    const existing = grouped[key].chapters[chapterKey];
+    if (!existing || (entry.timestamp || 0) > (existing.completedAt || 0)) {
+      grouped[key].chapters[chapterKey] = {
+        completed: entry.completed || false,
+        completedAt: entry.timestamp || Date.now(),
+        timeSpent: entry.timeSpent || 0,
+      };
+    }
+    grouped[key].ids.push(entry.id);
   }
-
-  return { success: true, results };
+  return grouped;
 }
 
 /**
- * Check if device is online and setup listeners
+ * Sync offline data when online — with batch sync, LWW merge, and retry
+ */
+export async function syncOfflineData() {
+  if (!navigator.onLine) {
+    return { success: false, message: "Device is offline", synced: 0, failed: 0 };
+  }
+
+  if (syncInProgress) {
+    return { success: false, message: "Sync already in progress", synced: 0, failed: 0 };
+  }
+
+  syncInProgress = true;
+
+  try {
+    const unsyncedProgress = await getUnsyncedProgress();
+    if (unsyncedProgress.length === 0) {
+      return { success: true, message: "Nothing to sync", synced: 0, failed: 0 };
+    }
+
+    // Group by course for batch sync
+    const grouped = groupByCourse(unsyncedProgress);
+    let synced = 0;
+    let failed = 0;
+    const conflicts = [];
+
+    for (const [courseId, group] of Object.entries(grouped)) {
+      let lastError = null;
+
+      // Retry with exponential backoff
+      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+        try {
+          const response = await fetch("/api/progress/sync", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              courseId: group.courseId,
+              courseType: group.courseType,
+              chapters: group.chapters,
+              clientTimestamp: Date.now(),
+            }),
+          });
+
+          if (response.ok) {
+            const data = await response.json();
+            // Mark all related IndexedDB records as synced
+            for (const id of group.ids) {
+              await markProgressSynced(id);
+            }
+            synced += group.ids.length;
+            if (data.conflicts?.length > 0) {
+              conflicts.push(...data.conflicts);
+            }
+            lastError = null;
+            break; // Success — exit retry loop
+          } else if (response.status === 401) {
+            // Auth error — don't retry
+            lastError = "Unauthorized";
+            break;
+          } else {
+            lastError = `Server error (${response.status})`;
+          }
+        } catch (error) {
+          lastError = error.message;
+        }
+
+        // Exponential backoff before retry
+        if (attempt < MAX_RETRIES - 1) {
+          await new Promise((r) => setTimeout(r, BASE_DELAY_MS * Math.pow(2, attempt)));
+        }
+      }
+
+      if (lastError) {
+        failed += group.ids.length;
+        console.warn(`Failed to sync course ${courseId}:`, lastError);
+      }
+    }
+
+    return { success: true, synced, failed, conflicts };
+  } finally {
+    syncInProgress = false;
+  }
+}
+
+/**
+ * Check if device is online and setup listeners.
+ * Returns a cleanup function to remove listeners.
  */
 export function setupOfflineListeners(onOnline, onOffline) {
-  window.addEventListener("online", () => {
-    console.log("Device is online");
-    syncOfflineData();
+  const handleOnline = () => {
     if (onOnline) onOnline();
-  });
+  };
 
-  window.addEventListener("offline", () => {
-    console.log("Device is offline");
+  const handleOffline = () => {
     if (onOffline) onOffline();
-  });
+  };
+
+  window.addEventListener("online", handleOnline);
+  window.addEventListener("offline", handleOffline);
+
+  // Return cleanup function
+  return () => {
+    window.removeEventListener("online", handleOnline);
+    window.removeEventListener("offline", handleOffline);
+  };
 }


### PR DESCRIPTION
## Fix: Desynchronized Offline State and Conflict Resolution

Closes #180

### Problem
The offline sync system had several critical issues:
- **No conflict resolution** — offline progress blindly overwrote server data (or vice versa) with no merge strategy
- **No authentication** on the sync endpoint — anyone could POST arbitrary progress
- **Duplicate records** in IndexedDB — auto-increment IDs caused the same chapter progress to be stored multiple times
- **Duplicate sync triggers** — both `useOffline` hook and `OfflineIndicator` component registered their own `online`/`offline` event listeners, causing multiple simultaneous sync attempts
- **No retry logic** — a single failed network request meant progress was lost
- **No Background Sync** — the service worker had no support for deferred sync when connectivity was restored
- **No anti-spoofing** — progress could be marked complete with zero time spent

### Solution

#### Server-Side (`/api/progress/sync`)
- **Authentication**: All endpoints require a valid session via `getServerSession()`
- **GET endpoint**: Fetch current server-side progress for a course (for client-side comparison)
- **POST with LWW merge**: Uses Firestore transactions for atomic last-write-wins merging — each chapter's progress is compared by timestamp, and the newer value wins
- **Anti-spoofing**: Rejects chapter completions with `timeSpent < 30 seconds`
- **Conflict reporting**: Response includes an array of conflicts that were resolved and count of rejected chapters

#### Client-Side (`offline.js`)
- **Deduplication**: `saveProgressOffline()` checks for existing unsynced records with the same `courseId + chapter` — updates in place instead of creating duplicates
- **Batch sync**: `syncOfflineData()` groups unsynced items by `courseId` and sends one POST per course (fewer network requests)
- **Retry with exponential backoff**: Up to 3 attempts with 1s/2s/4s delays
- **Concurrency guard**: Prevents overlapping sync operations via `syncInProgress` flag
- **Cleanup-friendly listeners**: `setupOfflineListeners()` returns a cleanup function for proper React effect teardown
- **Background Sync registration**: Automatically registers `sync-progress` tag when saving offline

#### Hook (`useOffline.js`)
- **Single source of truth**: Only one place registers `online`/`offline` listeners (via `setupOfflineListeners`), with proper cleanup
- **Sync state**: Exposes `isSyncing`, `syncResult`, and `triggerSync` for UI feedback
- **Resilient saves**: Online progress saves fall back to offline storage on network/server errors
- **Proper chapter format**: Formats progress data to match the new batch API format

#### UI (`OfflineIndicator.jsx`)
- **No duplicate listeners**: Consumes `useOffline()` hook instead of calling `setupOfflineListeners` directly
- **Detailed feedback**: Shows sync results — success count, failure count, conflict count
- **Visual states**: Red (offline), blue (syncing with spinner), green (success), yellow (partial failures)
- **Auto-dismiss**: Banners automatically hide after 2–5 seconds

#### Service Worker
- **Background Sync API**: `sync` event handler reads IndexedDB and batch-POSTs unsynced progress when connectivity is restored
- **API request isolation**: API calls bypass the cache and return a structured offline error when disconnected
- **Stale-while-revalidate**: Non-API cached responses are served immediately while updating in background
- **Proper lifecycle**: `skipWaiting()` + `clients.claim()` for immediate activation

### Files Changed
| File | Change |
|------|--------|
| `src/app/api/progress/sync/route.js` | Rewritten with auth, GET/POST, LWW merge, anti-spoofing |
| `src/lib/offline.js` | Deduplication, batch sync, retry, cleanup listeners |
| `src/hooks/useOffline.js` | Single listener source, sync state, error handling |
| `src/components/OfflineIndicator.jsx` | Uses hook, detailed feedback, auto-dismiss |
| `public/service-worker.js` | Background Sync, API isolation, stale-while-revalidate |
