### PR TITLE
fix: Memory Leaks in Client-Side Markdown/3D Rendering (#179)

### DIFF
--- a/src/components/Landing/AdvancedHero.jsx
+++ b/src/components/Landing/AdvancedHero.jsx
@@ -9,54 +9,58 @@ const AdvancedHero = () => {
   const dotsRef = useRef(null);
 
   useEffect(() => {
-    // Animate title
-    gsap.from(".hero-title", {
-      opacity: 0,
-      y: 50,
-      duration: 1,
-      ease: "power3.out",
-    });
-
-    gsap.from(".hero-subtitle", {
-      opacity: 0,
-      y: 30,
-      duration: 1,
-      delay: 0.3,
-      ease: "power3.out",
-    });
-
-    gsap.from(".hero-description", {
-      opacity: 0,
-      y: 20,
-      duration: 1,
-      delay: 0.5,
-      ease: "power3.out",
-    });
-
-    gsap.from(".hero-cta", {
-      opacity: 0,
-      scale: 0.9,
-      duration: 0.8,
-      delay: 0.7,
-      ease: "back.out(1.7)",
-    });
-
-    // Animate dots
-    const dots = dotsRef.current?.querySelectorAll('.dot');
-    if (dots) {
-      gsap.to(dots, {
-        opacity: 0.3,
-        scale: 1.2,
-        duration: 2,
-        stagger: {
-          amount: 3,
-          from: "random",
-          repeat: -1,
-          yoyo: true,
-        },
-        ease: "power1.inOut",
+    const ctx = gsap.context(() => {
+      // Animate title
+      gsap.from(".hero-title", {
+        opacity: 0,
+        y: 50,
+        duration: 1,
+        ease: "power3.out",
       });
-    }
+
+      gsap.from(".hero-subtitle", {
+        opacity: 0,
+        y: 30,
+        duration: 1,
+        delay: 0.3,
+        ease: "power3.out",
+      });
+
+      gsap.from(".hero-description", {
+        opacity: 0,
+        y: 20,
+        duration: 1,
+        delay: 0.5,
+        ease: "power3.out",
+      });
+
+      gsap.from(".hero-cta", {
+        opacity: 0,
+        scale: 0.9,
+        duration: 0.8,
+        delay: 0.7,
+        ease: "back.out(1.7)",
+      });
+
+      // Animate dots
+      const dots = dotsRef.current?.querySelectorAll('.dot');
+      if (dots) {
+        gsap.to(dots, {
+          opacity: 0.3,
+          scale: 1.2,
+          duration: 2,
+          stagger: {
+            amount: 3,
+            from: "random",
+            repeat: -1,
+            yoyo: true,
+          },
+          ease: "power1.inOut",
+        });
+      }
+    }, heroRef);
+
+    return () => ctx.revert();
   }, []);
 
   // Generate dots

--- a/src/components/Landing/AnimatedCounter.jsx
+++ b/src/components/Landing/AnimatedCounter.jsx
@@ -1,10 +1,35 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 
 const AnimatedCounter = ({ end, duration = 2000, suffix = "", prefix = "" }) => {
   const [count, setCount] = useState(0);
   const [hasAnimated, setHasAnimated] = useState(false);
   const ref = useRef(null);
+  const rafRef = useRef(null);
+
+  const animateCount = useCallback(() => {
+    const startTime = performance.now();
+    const startValue = 0;
+
+    const updateCount = (currentTime) => {
+      const elapsed = currentTime - startTime;
+      const progress = Math.min(elapsed / duration, 1);
+
+      // Easing function (ease-out)
+      const easeOut = 1 - Math.pow(1 - progress, 3);
+
+      const currentCount = Math.floor(startValue + (end - startValue) * easeOut);
+      setCount(currentCount);
+
+      if (progress < 1) {
+        rafRef.current = requestAnimationFrame(updateCount);
+      } else {
+        setCount(end);
+      }
+    };
+
+    rafRef.current = requestAnimationFrame(updateCount);
+  }, [end, duration]);
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -23,32 +48,11 @@ const AnimatedCounter = ({ end, duration = 2000, suffix = "", prefix = "" }) => 
       observer.observe(ref.current);
     }
 
-    return () => observer.disconnect();
-  }, [hasAnimated]);
-
-  const animateCount = () => {
-    const startTime = performance.now();
-    const startValue = 0;
-
-    const updateCount = (currentTime) => {
-      const elapsed = currentTime - startTime;
-      const progress = Math.min(elapsed / duration, 1);
-
-      // Easing function (ease-out)
-      const easeOut = 1 - Math.pow(1 - progress, 3);
-
-      const currentCount = Math.floor(startValue + (end - startValue) * easeOut);
-      setCount(currentCount);
-
-      if (progress < 1) {
-        requestAnimationFrame(updateCount);
-      } else {
-        setCount(end);
-      }
+    return () => {
+      observer.disconnect();
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
-
-    requestAnimationFrame(updateCount);
-  };
+  }, [hasAnimated, animateCount]);
 
   return (
     <span ref={ref} className="tabular-nums">

--- a/src/components/Landing/ParticleBackground.jsx
+++ b/src/components/Landing/ParticleBackground.jsx
@@ -78,14 +78,15 @@ const ParticleBackground = () => {
     createParticles();
     drawParticles();
 
-    window.addEventListener("resize", () => {
+    const handleResize = () => {
       resize();
       createParticles();
-    });
+    };
+    window.addEventListener("resize", handleResize);
 
     return () => {
       cancelAnimationFrame(animationId);
-      window.removeEventListener("resize", resize);
+      window.removeEventListener("resize", handleResize);
     };
   }, []);
 

--- a/src/components/MarkDown.jsx
+++ b/src/components/MarkDown.jsx
@@ -55,33 +55,31 @@ const MarkDown = ({ content }) => {
   const [theme, setTheme] = useState("light");
   const { nightMode } = useNightMode();
 
-  // Listen for theme changes
+  // Listen for theme changes via storage events + MutationObserver (no polling)
   useEffect(() => {
     const savedTheme = localStorage.getItem("theme") || "light";
     setTheme(savedTheme);
 
-    // Listen for theme changes
-    const handleThemeChange = () => {
+    const syncTheme = () => {
       const currentTheme = localStorage.getItem("theme") || "light";
       setTheme(currentTheme);
     };
 
     // Listen for storage events (theme changes in other tabs)
-    window.addEventListener("storage", handleThemeChange);
+    window.addEventListener("storage", syncTheme);
 
-    // Also check periodically for theme changes (fallback)
-    const interval = setInterval(() => {
-      const currentTheme = localStorage.getItem("theme") || "light";
-      if (currentTheme !== theme) {
-        setTheme(currentTheme);
-      }
-    }, 100);
+    // Watch for class changes on <html> to detect same-tab theme toggles
+    const observer = new MutationObserver(syncTheme);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class", "data-theme"],
+    });
 
     return () => {
-      window.removeEventListener("storage", handleThemeChange);
-      clearInterval(interval);
+      window.removeEventListener("storage", syncTheme);
+      observer.disconnect();
     };
-  }, [theme]);
+  }, []);
 
   // Select appropriate theme based on current mode
   const codeTheme = theme === "dark" ? coldarkDark : coldarkCold;

--- a/src/components/chapter_content/page.jsx
+++ b/src/components/chapter_content/page.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { ArrowLeft, ArrowRight, Clock } from "lucide-react";
 import Sidebar from "../sidebar/page";
@@ -69,6 +69,17 @@ const Page = ({ chapter, roadmapId }) => {
     const [certDialogOpen, setCertDialogOpen] = useState(false);
     const { showLoader, hideLoader } = loader();
     const { user } = useAuth();
+    const pollingRef = useRef(null);
+
+    // Clean up polling interval on unmount
+    useEffect(() => {
+        return () => {
+            if (pollingRef.current) {
+                clearInterval(pollingRef.current);
+                pollingRef.current = null;
+            }
+        };
+    }, []);
 
     async function getRoadmap() {
         try {
@@ -170,6 +181,7 @@ const Page = ({ chapter, roadmapId }) => {
                     reject(error);
                 }
             }, 3000);
+            pollingRef.current = fetchInterval;
         });
     }
 

--- a/src/components/gamification/AchievementConfetti.jsx
+++ b/src/components/gamification/AchievementConfetti.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 import confetti from "canvas-confetti";
 
 // XP milestones that trigger celebrations
@@ -10,6 +10,15 @@ const XP_MILESTONES = [100, 250, 500, 1000, 2500, 5000, 10000, 25000, 50000, 100
 const LEVEL_MILESTONES = [5, 10, 15, 20, 25, 50, 100];
 
 export const useAchievementConfetti = () => {
+  const rafRef = useRef(null);
+
+  // Clean up any pending rAF on unmount
+  useEffect(() => {
+    return () => {
+      if (rafRef.current) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
   const fireConfetti = useCallback((type = "default") => {
     const defaults = {
       origin: { y: 0.7 },
@@ -51,7 +60,7 @@ export const useAchievementConfetti = () => {
           });
 
           if (Date.now() < end) {
-            requestAnimationFrame(frame);
+            rafRef.current = requestAnimationFrame(frame);
           }
         };
         frame();

--- a/src/components/gamification/Leaderboard.jsx
+++ b/src/components/gamification/Leaderboard.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -17,13 +17,19 @@ export default function Leaderboard({ currentUserId }) {
   const [animatingUsers, setAnimatingUsers] = useState(new Set());
   const [loading, setLoading] = useState(true);
   const isFirstLoad = useRef(true);
+  const animationTimers = useRef([]);
 
   useEffect(() => {
     fetchLeaderboard();
 
     // Refresh leaderboard every 10 seconds for real-time updates
     const interval = setInterval(fetchLeaderboard, 10000);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      // Clear any pending animation timers
+      animationTimers.current.forEach(clearTimeout);
+      animationTimers.current = [];
+    };
   }, []);
 
   const fetchLeaderboard = async () => {
@@ -54,13 +60,14 @@ export default function Leaderboard({ currentUserId }) {
             if (prevRank !== undefined && prevRank !== newRank) {
               newAnimating.add(`${period}_${user.id}`);
               // Clear animation after 2 seconds
-              setTimeout(() => {
+              const timer = setTimeout(() => {
                 setAnimatingUsers(prev => {
                   const next = new Set(prev);
                   next.delete(`${period}_${user.id}`);
                   return next;
                 });
               }, 2000);
+              animationTimers.current.push(timer);
             }
 
             newPreviousRanks[`${period}_${user.id}`] = newRank;

--- a/src/components/gamification/LevelUpModal.jsx
+++ b/src/components/gamification/LevelUpModal.jsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useSpring, animated, config } from "@react-spring/web";
 import confetti from "canvas-confetti";
 import { X, Star, Trophy, Zap, Crown, Sparkles } from "lucide-react";
@@ -26,6 +26,8 @@ export default function LevelUpModal({
 }) {
   const [showParticles, setShowParticles] = useState(false);
   const [badgeRevealed, setBadgeRevealed] = useState(false);
+  const rafRef = useRef(null);
+  const timersRef = useRef([]);
 
   // Get badge for this level (if any)
   const badge = LEVEL_BADGES[newLevel];
@@ -71,8 +73,10 @@ export default function LevelUpModal({
       // Fire confetti
       const duration = 3000;
       const end = Date.now() + duration;
+      let cancelled = false;
 
       const frame = () => {
+        if (cancelled) return;
         confetti({
           particleCount: 3,
           angle: 60,
@@ -91,18 +95,27 @@ export default function LevelUpModal({
         });
 
         if (Date.now() < end) {
-          requestAnimationFrame(frame);
+          rafRef.current = requestAnimationFrame(frame);
         }
       };
       frame();
 
       // Reveal badge after delay
       if (badge) {
-        setTimeout(() => setBadgeRevealed(true), 1500);
+        const t1 = setTimeout(() => setBadgeRevealed(true), 1500);
+        timersRef.current.push(t1);
       }
 
       // Hide particles after duration
-      setTimeout(() => setShowParticles(false), 3000);
+      const t2 = setTimeout(() => setShowParticles(false), 3000);
+      timersRef.current.push(t2);
+
+      return () => {
+        cancelled = true;
+        if (rafRef.current) cancelAnimationFrame(rafRef.current);
+        timersRef.current.forEach(clearTimeout);
+        timersRef.current = [];
+      };
     } else {
       setBadgeRevealed(false);
     }

--- a/src/components/premium/PremiumCelebration.jsx
+++ b/src/components/premium/PremiumCelebration.jsx
@@ -7,6 +7,9 @@ import { Crown, Sparkles, Star, Zap } from "lucide-react";
 export default function PremiumCelebration({ isOpen, onClose }) {
   const [showContent, setShowContent] = useState(false);
   const audioRef = useRef(null);
+  const audioContextRef = useRef(null);
+  const timersRef = useRef([]);
+  const confettiIntervalRef = useRef(null);
 
   useEffect(() => {
     if (isOpen) {
@@ -17,14 +20,29 @@ export default function PremiumCelebration({ isOpen, onClose }) {
       fireConfettiSequence();
 
       // Show content after a delay
-      setTimeout(() => setShowContent(true), 500);
+      const t1 = setTimeout(() => setShowContent(true), 500);
+      timersRef.current.push(t1);
 
       // Auto close after 6 seconds
       const timer = setTimeout(() => {
         onClose?.();
       }, 6000);
+      timersRef.current.push(timer);
 
-      return () => clearTimeout(timer);
+      return () => {
+        // Clean up all timers
+        timersRef.current.forEach(clearTimeout);
+        timersRef.current = [];
+        if (confettiIntervalRef.current) {
+          clearInterval(confettiIntervalRef.current);
+          confettiIntervalRef.current = null;
+        }
+        // Close AudioContext
+        if (audioContextRef.current) {
+          audioContextRef.current.close().catch(() => {});
+          audioContextRef.current = null;
+        }
+      };
     } else {
       setShowContent(false);
     }
@@ -34,6 +52,7 @@ export default function PremiumCelebration({ isOpen, onClose }) {
     try {
       // Create audio context for celebration sound
       const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+      audioContextRef.current = audioContext;
 
       // Play a victory fanfare sequence
       const playNote = (frequency, startTime, duration, gain = 0.3) => {
@@ -83,7 +102,7 @@ export default function PremiumCelebration({ isOpen, onClose }) {
     });
 
     // Side cannons
-    setTimeout(() => {
+    const t1 = setTimeout(() => {
       confetti({
         particleCount: 80,
         angle: 60,
@@ -101,6 +120,7 @@ export default function PremiumCelebration({ isOpen, onClose }) {
         zIndex: 10000,
       });
     }, 300);
+    timersRef.current.push(t1);
 
     // Continuous confetti rain
     const interval = setInterval(() => {
@@ -126,9 +146,10 @@ export default function PremiumCelebration({ isOpen, onClose }) {
         zIndex: 10000,
       });
     }, 100);
+    confettiIntervalRef.current = interval;
 
     // Star bursts
-    setTimeout(() => {
+    const t2 = setTimeout(() => {
       confetti({
         particleCount: 100,
         spread: 360,
@@ -138,9 +159,10 @@ export default function PremiumCelebration({ isOpen, onClose }) {
         zIndex: 10000,
       });
     }, 1000);
+    timersRef.current.push(t2);
 
     // Final explosion
-    setTimeout(() => {
+    const t3 = setTimeout(() => {
       confetti({
         particleCount: 200,
         spread: 180,
@@ -149,6 +171,7 @@ export default function PremiumCelebration({ isOpen, onClose }) {
         zIndex: 10000,
       });
     }, 2000);
+    timersRef.current.push(t3);
   };
 
   if (!isOpen) return null;


### PR DESCRIPTION
## Fix: Memory Leaks in Client-Side Markdown/3D Rendering

Closes #179

### Problem

Long study sessions (15–20 min of navigating between courses) caused the browser tab to accumulate leaked resources — orphaned intervals, animation frames, event listeners, gsap tweens, and AudioContexts — leading to frame drops, UI lag, and eventual OOM crashes on low-end devices.

### Root Causes Identified & Fixed

| Component | Leak | Fix |
|-----------|------|-----|
| **MarkDown.jsx** | 100ms \setInterval\ polling localStorage for theme changes — fires 600 times/minute even when idle | Replaced with a \MutationObserver\ on \<html>\ class/data-theme attributes + \storage\ event listener. Event-driven, zero CPU waste. |
| **AdvancedHero.jsx** | Multiple \gsap.from()\ and an infinite-repeat \gsap.to()\ on dots — never killed on unmount | Wrapped all animations in \gsap.context(heroRef)\ and call \ctx.revert()\ in cleanup. Kills all tweens scoped to the component. |
| **ParticleBackground.jsx** | \esize\ event listener added via anonymous arrow function, but \emoveEventListener\ tried to remove the named \esize\ function — different references, listener never removed | Extracted the handler into a named \handleResize\ variable used for both add and remove. |
| **AnimatedCounter.jsx** | Recursive \equestAnimationFrame\ chain with no cancellation — if component unmounts mid-animation, rAF keeps calling \setCount()\ on dead component | Stored rAF ID in \useRef\, cancel via \cancelAnimationFrame\ in useEffect cleanup. |
| **LevelUpModal.jsx** | Confetti rAF loop (3s) + 2 untracked \setTimeout\s (badge reveal at 1.5s, particle hide at 3s) — all fire after modal closes | Track rAF ID and all timeout IDs in refs, cancel all in useEffect cleanup with \cancelled\ flag. |
| **AchievementConfetti.jsx** | \level_up\ case starts a 2s rAF loop with no cancellation on hook unmount | Store rAF ID in \useRef\, cancel in useEffect cleanup. |
| **Leaderboard.jsx** | Multiple \setTimeout(..., 2000)\ for clearing animation state — never cancelled on unmount, call \setAnimatingUsers\ on dead component | Track all animation timeout IDs in a ref array, clear all in useEffect cleanup alongside the polling interval. |
| **PremiumCelebration.jsx** | \setTimeout\ (show content), \setInterval\ (confetti rain), 3 more \setTimeout\s (side cannons, star bursts, final explosion), and an \AudioContext\ — only the 6s auto-close timer was cleaned up | Track all timers in ref arrays, store confetti interval in ref, close \AudioContext\ — all cleaned up on unmount. |
| **chapter_content/page.jsx** | 3s polling \setInterval\ in \handlePendingChapter()\ — cleared on all resolution paths but not if the component unmounts while polling is active | Store interval ID in \useRef\, add \useEffect\ cleanup to clear on unmount. |

### Technical Approach

- **Event-driven over polling**: The 100ms theme interval (MarkDown.jsx) was the single biggest offender — replaced with \MutationObserver\ which fires only when the DOM actually changes.
- **gsap.context()**: Scopes all gsap animations to a container ref and provides a single \evert()\ call that kills everything — the canonical way to clean up gsap in React.
- **Ref-based tracking**: All \setTimeout\/\setInterval\/\equestAnimationFrame\ IDs are stored in \useRef\ so cleanup functions can cancel them without stale closure issues.
- **Cancellation flags**: rAF loops check a \cancelled\ boolean to stop recursion immediately when cleanup fires.

### Files Changed (9)

| File | Lines Changed |
|------|--------------|
| \src/components/MarkDown.jsx\ | Replaced setInterval with MutationObserver |
| \src/components/Landing/AdvancedHero.jsx\ | gsap.context + revert cleanup |
| \src/components/Landing/ParticleBackground.jsx\ | Fixed event listener reference |
| \src/components/Landing/AnimatedCounter.jsx\ | rAF ref + cancelAnimationFrame |
| \src/components/gamification/LevelUpModal.jsx\ | rAF + setTimeout ref cleanup |
| \src/components/gamification/AchievementConfetti.jsx\ | rAF ref cleanup |
| \src/components/gamification/Leaderboard.jsx\ | setTimeout ref array cleanup |
| \src/components/premium/PremiumCelebration.jsx\ | Full timer + AudioContext cleanup |
| \src/components/chapter_content/page.jsx\ | Polling interval ref + unmount cleanup |