### PR TITLE
fix: Remove Duplicate Status (Archive) Filter Dropdown in Roadmap Page (#173)

### DIFF
--- a/src/app/roadmap/page.jsx
+++ b/src/app/roadmap/page.jsx
@@ -366,18 +366,6 @@ export default function page() {
                                 </SelectContent>
                             </Select>
 
-                            {/* Archive Filter */}
-                            <Select value={archiveFilter} onValueChange={setArchiveFilter}>
-                                <SelectTrigger className="w-35 h-9 bg-card/50 backdrop-blur-sm border-border/50">
-                                    <SelectValue placeholder="Status" />
-                                </SelectTrigger>
-                                <SelectContent>
-                                    <SelectItem value="active">Active</SelectItem>
-                                    <SelectItem value="archived">Archived</SelectItem>
-                                    <SelectItem value="all">All Courses</SelectItem>
-                                </SelectContent>
-                            </Select>
-
                             {/* Sort By */}
                             <Select value={sortBy} onValueChange={setSortBy}>
                                 <SelectTrigger className="w-40 h-9 bg-card/50 backdrop-blur-sm border-border/50">


### PR DESCRIPTION
## Fix: Duplicate Status Filter Dropdowns in Roadmap Page

Closes #173

### Problem

The filter bar on the Roadmap page contains **two identical** \Select\ components for filtering by Status (Active / Archived / All Courses). Both are bound to the same \rchiveFilter\ state and render the exact same options — one labelled \{/* Archive Status Filter */}\ (line 345) and an identical copy labelled \{/* Archive Filter */}\ (line 370).

### Fix

Removed the duplicate \Select\ component (the second one at line 370). The first instance at line 345 is kept and continues to function identically.

### Files Changed

| File | Change |
|------|--------|
| \src/app/roadmap/page.jsx\ | Deleted the duplicate \rchiveFilter\ Select component (12 lines) |