### PR TITLE
fix: Difficulty Filter In-depth Shows No Results Due to Value Mismatch (#172)

### DIFF
--- a/src/app/roadmap/page.jsx
+++ b/src/app/roadmap/page.jsx
@@ -362,7 +362,7 @@ export default function page() {
                                     <SelectItem value="all">All Difficulties</SelectItem>
                                     <SelectItem value="fast">Fast-paced</SelectItem>
                                     <SelectItem value="balanced">Balanced</SelectItem>
-                                    <SelectItem value="in-depth">In-depth</SelectItem>
+                                    <SelectItem value="inDepth">In-depth</SelectItem>
                                 </SelectContent>
                             </Select>
 


### PR DESCRIPTION
## Fix: Difficulty Filter In-depth Shows No Results

Closes #172

### Problem

On the Roadmap (Your Courses) page, selecting In-depth from the Difficulty dropdown returns no results even when In-depth courses exist.

**Root cause:** The `SelectItem` value is `in-depth` (kebab-case), but the backend stores difficulty as `inDepth` (camelCase) in Firestore. The filtering logic does a strict equality check (`course.difficulty === difficultyFilter`), so `inDepth === in-depth` evaluates to `false` and all In-depth courses are filtered out.

### Fix

Changed the `SelectItem` value from `in-depth` to `inDepth` in the Difficulty filter dropdown to match the backend format.

### Files Changed

| File | Change |
|------|--------|
| `src/app/roadmap/page.jsx` (line 365) | `value=in-depth` to `value=inDepth` |