### PR TITLE
fix: Missing Course Progress Bar and Completion Email Not Triggering (#158)

### DIFF
--- a/src/app/api/tasks/route.js
+++ b/src/app/api/tasks/route.js
@@ -79,23 +79,29 @@ async function completeChapter(chapter, roadmapId, user) {
 
     const allDone = completedChapters.length === updatedChapters.length;
     if (allDone) {
+      // Update chapters and completion flag atomically to prevent race conditions
       await docRef.update({
+        chapters: updatedChapters,
         completed: true,
       });
 
-      // Trigger completion email if just finished
-      if (!wasCompleted) {
+      // Trigger completion email if just finished (guard with completionEmailSent flag)
+      if (!wasCompleted && !roadmap.completionEmailSent) {
         try {
+          // Mark email as sent first to prevent duplicate sends from concurrent requests
+          await docRef.update({ completionEmailSent: true });
           const { sendCourseCompletionEmail } = await import("@/lib/brevo");
           await sendCourseCompletionEmail(user.email, user.name, roadmap.courseTitle || "Your Roadmap");
         } catch (emailError) {
           console.error("Failed to send roadmap completion email:", emailError);
+          // Don't revert the flag — we'd rather skip the email than send it twice
         }
       }
+    } else {
+      await docRef.update({
+        chapters: updatedChapters,
+      });
     }
-    await docRef.update({
-      chapters: updatedChapters,
-    });
     return allDone;
   }
   return false;

--- a/src/components/Home/RoadMap.jsx
+++ b/src/components/Home/RoadMap.jsx
@@ -1,10 +1,11 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useState, useContext } from "react";
-import { CircleCheckIcon, Clock, Copy } from "lucide-react";
+import { CircleCheckIcon, Clock, Copy, Trophy } from "lucide-react";
 import xpContext from "@/contexts/xp";
 import { useAuth } from "@/contexts/auth";
 import { calculateEstimatedTime } from "@/lib/time-utils";
+import { AnimatedProgress } from "@/components/ui/animated-progress";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { loader } from "@/components/ui/Custom/ToastLoader";
@@ -111,6 +112,42 @@ function Roadmap({ roadMap, id }) {
             </Button>
           </div>
         </div>
+
+        {/* Course Progress Bar */}
+        {(() => {
+          const completedChapters = roadMap.chapters.filter(ch => ch.completed).length;
+          const totalChapters = roadMap.chapters.length;
+          const progress = totalChapters > 0 ? Math.round((completedChapters / totalChapters) * 100) : 0;
+          const progressColor = progress === 100 ? "green" : progress >= 50 ? "blue" : progress > 0 ? "yellow" : "default";
+          return (
+            <div className="mt-4 ml-2 mr-2 space-y-2">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground font-medium">
+                  {completedChapters} of {totalChapters} chapters completed
+                </span>
+                <span className={`font-semibold ${
+                  progress === 100 ? "text-green-600 dark:text-green-400" :
+                  progress > 0 ? "text-blue-600 dark:text-blue-400" :
+                  "text-muted-foreground"
+                }`}>
+                  {progress}%
+                </span>
+              </div>
+              <AnimatedProgress
+                value={progress}
+                color={progressColor}
+                size="default"
+                delay={300}
+              />
+              {progress === 100 && (
+                <div className="flex items-center gap-1.5 text-green-600 dark:text-green-400 text-sm font-medium">
+                  <Trophy className="h-4 w-4" />
+                  <span>Course completed! Certificate unlocked.</span>
+                </div>
+              )}
+            </div>
+          );
+        })()}
 
         {/* Estimated Time Badge */}
         <div className="flex items-center gap-2 mt-3 ml-2">

--- a/src/components/chapter_content/page.jsx
+++ b/src/components/chapter_content/page.jsx
@@ -352,6 +352,36 @@ const Page = ({ chapter, roadmapId }) => {
                 <div className="flex flex-col md:flex-row">
                     <Sidebar roadmap={roadmap} id={roadmapId} courseTitle={roadmap?.courseTitle || roadmap?.title || ""} />
                     <div className="flex-1 p-8 lg:ml-96 lg:w-[60vw] max-sm:p-4 bg-background ">
+                        {/* Overall Course Progress */}
+                        {roadmap?.chapters && roadmap.chapters.length > 0 && (() => {
+                            const completedChapters = roadmap.chapters.filter(ch => ch.completed).length;
+                            const totalChapters = roadmap.chapters.length;
+                            const courseProgress = Math.round((completedChapters / totalChapters) * 100);
+                            const progressColor = courseProgress === 100 ? "green" : courseProgress >= 50 ? "blue" : courseProgress > 0 ? "yellow" : "default";
+                            return (
+                                <div className="mb-6 p-4 rounded-lg border bg-card/50 backdrop-blur-sm">
+                                    <div className="flex items-center justify-between text-sm mb-2">
+                                        <span className="text-muted-foreground font-medium">
+                                            Course Progress: {completedChapters} of {totalChapters} chapters
+                                        </span>
+                                        <span className={`font-semibold ${
+                                            courseProgress === 100 ? "text-green-600 dark:text-green-400" :
+                                            courseProgress > 0 ? "text-blue-600 dark:text-blue-400" :
+                                            "text-muted-foreground"
+                                        }`}>
+                                            {courseProgress}%
+                                        </span>
+                                    </div>
+                                    <AnimatedProgress
+                                        value={courseProgress}
+                                        color={progressColor}
+                                        size="sm"
+                                        delay={200}
+                                    />
+                                </div>
+                            );
+                        })()}
+
                         {chapterData.chapterTitle && (
                             <div className="mb-4">
                                 <div className="flex items-start justify-between gap-4">


### PR DESCRIPTION
## Fix: Missing Course Progress Bar & Completion Email Not Triggering

Closes #158

### Problem

1. **No Progress Bar in Course Roadmap** — The course detail view (chapter listing) and the chapter content view do not display a course-level progress bar. Users cannot track how many chapters they have completed out of the total.

2. **Completion Email Not Triggering** — After reaching 100% course completion, the automated congratulatory email fails to send reliably due to:
   - Two separate Firestore updates (`completed: true` then `chapters: updatedChapters`) creating a race window where a concurrent request may see `wasCompleted = true` and skip the email
   - No persistent guard flag to prevent duplicate email attempts

### Changes

| File | Change |
|------|--------|
| `src/components/Home/RoadMap.jsx` | Added animated course progress bar showing completed/total chapters with percentage, color-coded by progress (yellow < 50%, blue < 100%, green = 100%), and a trophy completion message when 100% is reached. Uses `AnimatedProgress` component. |
| `src/components/chapter_content/page.jsx` | Added overall course progress bar at the top of the chapter content view so users can see course-level progress while studying individual chapters. Appears in a styled card above the chapter title. |
| `src/app/api/tasks/route.js` | **Fixed completion email trigger**: Combined `chapters` and `completed` fields into a single atomic Firestore update to eliminate the race window. Added `completionEmailSent` flag as a persistent guard — set to `true` before sending to prevent duplicate emails from concurrent requests. |

### How It Works

**Progress Bar:**
- Calculates `completedChapters / totalChapters` from the `chapters` array (each chapter has a `completed` boolean)
- Uses the existing `AnimatedProgress` component with spring animation
- Color progression: default (0%) → yellow (1-49%) → blue (50-99%) → green (100%)
- Trophy icon + message appears at 100%: *Course completed! Certificate unlocked.*

**Completion Email Fix:**
- Before: Two separate updates → race condition → email skipped
- After: Single atomic update (`{ chapters, completed: true }`) + `completionEmailSent` flag checked before sending
- The flag is set optimistically before sending to ensure concurrent requests see it