### PR TITLE
Fix: Chapter Generation Error Handling with Meaningful Messages (#50)

### DIFF
--- a/src/app/api/chapter-prompt/route.js
+++ b/src/app/api/chapter-prompt/route.js
@@ -49,7 +49,10 @@ async function updateDatabase(content, chapter, roadmapId, session) {
     await taskDocRef.set({ ...tasks });
   } catch (error) {
     console.error("Error updating database:", error);
-    await docRef.delete();
+    await docRef.update({
+      process: "failed",
+      error: "Failed to save generated content. Please try again.",
+    });
   }
 }
 
@@ -119,6 +122,13 @@ export async function POST(req) {
 
   if (!session) {
     return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  if (!prompt || !number || !roadmapId) {
+    return NextResponse.json(
+      { message: "Missing required fields: prompt, number, and roadmapId are required" },
+      { status: 400 }
+    );
   }
 
   try {

--- a/src/app/api/get-chapter/[roadmapId]/[chapter]/route.js
+++ b/src/app/api/get-chapter/[roadmapId]/[chapter]/route.js
@@ -29,17 +29,31 @@ export async function GET(req, { params }) {
       .doc("task");
 
     const docSnap = await docRef.get();
-    const taskSnap = await taskDocRef.get();
-    if (docSnap.exists && docSnap.data().process === "pending") {
-      return NextResponse.json({ chapter: { process: "pending" } });
-    }
+
     if (!docSnap.exists) {
       return NextResponse.json({ message: "Chapter not found" }, { status: 404 });
     }
+
+    const data = docSnap.data();
+
+    if (data.process === "pending") {
+      return NextResponse.json({ chapter: { process: "pending" } });
+    }
+
+    if (data.process === "failed") {
+      return NextResponse.json({
+        chapter: {
+          process: "failed",
+          error: data.error || "Chapter generation failed. Please try again.",
+        },
+      });
+    }
+
+    const taskSnap = await taskDocRef.get();
     const tasks = Object.values(taskSnap?.data() || {});
 
     return NextResponse.json({
-      chapter: { ...docSnap.data(), tasks },
+      chapter: { ...data, tasks },
     });
   } catch (error) {
     return NextResponse.json({ message: error.message }, { status: 500 });

--- a/src/components/chapter_content/ChapterError.jsx
+++ b/src/components/chapter_content/ChapterError.jsx
@@ -1,14 +1,78 @@
 import React from "react";
+import { AlertTriangle, Clock, RefreshCw, ServerCrash, WifiOff } from "lucide-react";
+
+const getErrorDetails = (error) => {
+    if (!error) return { icon: AlertTriangle, title: "Something went wrong", color: "text-red-500" };
+
+    const lowerError = error.toLowerCase();
+
+    if (lowerError.includes("timed out") || lowerError.includes("taking too long")) {
+        return {
+            icon: Clock,
+            title: "Generation Timed Out",
+            color: "text-amber-500",
+            suggestion: "The AI took too long to generate this chapter. This can happen with complex topics. Please try again.",
+        };
+    }
+
+    if (lowerError.includes("parse") || lowerError.includes("json") || lowerError.includes("valid json")) {
+        return {
+            icon: ServerCrash,
+            title: "Content Processing Error",
+            color: "text-orange-500",
+            suggestion: "The generated content could not be processed correctly. Trying again usually resolves this.",
+        };
+    }
+
+    if (lowerError.includes("save") || lowerError.includes("database") || lowerError.includes("lost during processing")) {
+        return {
+            icon: ServerCrash,
+            title: "Storage Error",
+            color: "text-red-500",
+            suggestion: "The chapter was generated but could not be saved. Please try again.",
+        };
+    }
+
+    if (lowerError.includes("network") || lowerError.includes("fetch") || lowerError.includes("status")) {
+        return {
+            icon: WifiOff,
+            title: "Connection Error",
+            color: "text-blue-500",
+            suggestion: "There was a problem connecting to the server. Check your internet connection and try again.",
+        };
+    }
+
+    return {
+        icon: AlertTriangle,
+        title: "Chapter Generation Failed",
+        color: "text-red-500",
+        suggestion: "Something went wrong while generating this chapter. Please try again.",
+    };
+};
 
 const ChapterError = ({ fetchChapter, error }) => {
+    const { icon: Icon, title, color, suggestion } = getErrorDetails(error);
+
     return (
         <div className="min-h-screen bg-background p-6 flex items-center justify-center">
-            <div className="text-center">
-                <p className="text-xl text-red-500 mb-4">{error}</p>
+            <div className="text-center max-w-md">
+                <div className={`flex justify-center mb-4 ${color}`}>
+                    <Icon className="h-12 w-12" />
+                </div>
+                <h2 className="text-2xl font-bold mb-2">{title}</h2>
+                <p className="text-muted-foreground mb-4">
+                    {suggestion || error}
+                </p>
+                {error && suggestion && (
+                    <p className="text-sm text-muted-foreground/70 mb-6 border rounded-md p-3 bg-muted/30">
+                        Error details: {error}
+                    </p>
+                )}
                 <button
                     onClick={() => fetchChapter()}
-                    className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+                    className="inline-flex items-center gap-2 px-6 py-2.5 bg-blue-500 text-white rounded-md hover:bg-blue-600 transition-colors"
                 >
+                    <RefreshCw className="h-4 w-4" />
                     Try Again
                 </button>
             </div>

--- a/src/components/chapter_content/page.jsx
+++ b/src/components/chapter_content/page.jsx
@@ -105,8 +105,13 @@ const Page = ({ chapter, roadmapId }) => {
                 const data = await response.json();
 
                 if (data.chapter.process === "pending") {
-                    await handleNotFoundChapter();
+                    // Chapter is already being generated — just poll, don't re-trigger
                     await handlePendingChapter();
+                } else if (data.chapter.process === "failed") {
+                    setError(
+                        data.chapter.error ||
+                            "Chapter generation failed. Please try again."
+                    );
                 } else {
                     setChapterData(data.chapter.content);
                     setTasks(data.chapter.tasks);
@@ -118,7 +123,11 @@ const Page = ({ chapter, roadmapId }) => {
             }
         } catch (error) {
             console.error("Error fetching chapter:", error);
-            setError("Failed to load chapter content. Please try again later.");
+            if (!error._preserveMessage) {
+                setError(
+                    "Failed to load chapter content. Please try again later."
+                );
+            }
         } finally {
             setIsLoading(false);
         }
@@ -127,8 +136,25 @@ const Page = ({ chapter, roadmapId }) => {
     async function handlePendingChapter() {
         setGenerating(true);
 
+        const MAX_POLLS = 60; // 60 polls × 3s = 3 minute client-side timeout
+        let pollCount = 0;
+
         return new Promise((resolve, reject) => {
             const fetchInterval = setInterval(async () => {
+                pollCount++;
+
+                if (pollCount > MAX_POLLS) {
+                    clearInterval(fetchInterval);
+                    const err = new Error(
+                        "Chapter generation is taking too long. Please try again later."
+                    );
+                    err._preserveMessage = true;
+                    setError(err.message);
+                    setGenerating(false);
+                    reject(err);
+                    return;
+                }
+
                 try {
                     const res = await fetch(
                         `/api/get-chapter/${roadmapId}/${chapter}`
@@ -136,11 +162,13 @@ const Page = ({ chapter, roadmapId }) => {
 
                     if (res.status === 404) {
                         clearInterval(fetchInterval);
-                        toast.error(
-                            "There was an error while generating your chapter"
+                        const err = new Error(
+                            "Chapter could not be generated. The content may have been lost during processing."
                         );
+                        err._preserveMessage = true;
+                        setError(err.message);
                         setGenerating(false);
-                        reject(new Error("Chapter generation failed"));
+                        reject(err);
                         return;
                     }
 
@@ -158,15 +186,25 @@ const Page = ({ chapter, roadmapId }) => {
                         resolve();
                     } else if (chapterData.chapter.process === "failed") {
                         clearInterval(fetchInterval);
-                        setError(chapterData.chapter.error || "Chapter generation failed");
+                        const errorMsg =
+                            chapterData.chapter.error ||
+                            "Chapter generation failed. Please try again.";
+                        const err = new Error(errorMsg);
+                        err._preserveMessage = true;
+                        setError(errorMsg);
                         setGenerating(false);
-                        reject(new Error("Chapter generation failed"));
+                        reject(err);
                     }
                 } catch (error) {
                     clearInterval(fetchInterval);
                     setGenerating(false);
                     console.error("Error during polling:", error);
-                    toast.error("Error checking chapter generation status");
+                    if (!error._preserveMessage) {
+                        setError(
+                            "Error checking chapter generation status. Please try again."
+                        );
+                    }
+                    error._preserveMessage = true;
                     reject(error);
                 }
             }, 3000);
@@ -212,7 +250,13 @@ const Page = ({ chapter, roadmapId }) => {
             }
         } catch (error) {
             console.error("Error starting chapter generation:", error);
-            toast.error("Failed to start chapter generation.");
+            setGenerating(false);
+            const err = new Error(
+                "Failed to start chapter generation. Please try again."
+            );
+            err._preserveMessage = true;
+            setError(err.message);
+            throw err;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #50 — Chapter generation fails with no clear error message.

## Problem

When chapter generation failed, the system showed a generic "Failed" message with no meaningful context. Several silent failure points existed:

1. **Database write failure deleted the chapter doc** — content was generated successfully but if saving to Firestore failed, the doc was silently deleted, causing a confusing 404
2. **Duplicate generation triggered on pending chapters** — when a chapter was already being generated, the client re-triggered generation AND polled, creating race conditions
3. **Infinite client-side polling** — no timeout limit on polling, causing browsers to poll forever if a chapter got stuck
4. **Generic errors overwrote specific ones** — the outer catch block replaced specific error messages (e.g., "Generation timed out") with "Failed to load chapter content"
5. **Silent failures in generation start** — if starting generation failed, only a toast was shown without updating the error state, leaving the UI in a blank state

## Changes

### Backend — `chapter-prompt/route.js`
- **Fix silent doc deletion**: When `updateDatabase()` fails, mark the chapter as `process: "failed"` with a meaningful error message instead of deleting the document
- **Add input validation**: Validate `prompt`, `number`, and `roadmapId` parameters, returning 400 with a descriptive message if any are missing

### Backend — `get-chapter/[roadmapId]/[chapter]/route.js`
- **Explicit failed state handling**: Return a structured response with the error message when `process === "failed"`, instead of falling through to the default return
- **Skip unnecessary reads**: Don't fetch the tasks sub-document for failed chapters
- **Reorder checks**: Check existence before process status for clearer logic flow

### Client — `chapter_content/page.jsx`
- **Fix duplicate generation**: When chapter is already "pending", only poll — don't re-trigger generation via `handleNotFoundChapter()`
- **Add polling timeout**: 60 polls x 3s = 3-minute client-side timeout to prevent infinite polling
- **Preserve specific errors**: Use `_preserveMessage` flag so specific error messages from polling/generation aren't overwritten by generic catch-block text
- **Set error state on generation failure**: `handleNotFoundChapter` now sets `error` state instead of only showing a toast
- **Handle failed status in fetchChapter**: Explicitly check for `process === "failed"` and display the backend error message

### Client — `ChapterError.jsx`
- **Categorized error display**: Classify errors by type (timeout, parse/JSON, storage, network) with appropriate icons and colors
- **Contextual suggestions**: Show helpful suggestions based on error type (e.g., "The AI took too long..." for timeouts)
- **Error details section**: Show the raw error message in a details section below the suggestion
- **Enhanced UI**: Added icons (Clock, ServerCrash, WifiOff, AlertTriangle) and improved visual hierarchy

## Files Changed

| File | Changes |
|------|---------|
| `src/app/api/chapter-prompt/route.js` | Set failed status instead of deleting doc; add input validation |
| `src/app/api/get-chapter/[roadmapId]/[chapter]/route.js` | Explicit failed state response with error message |
| `src/components/chapter_content/page.jsx` | Fix duplicate generation, add polling timeout, preserve errors |
| `src/components/chapter_content/ChapterError.jsx` | Categorized error display with icons and suggestions |
