### PR TITLE
feat: Add GitHub Actions workflows for auto-commenting on issues and PRs (#159)

### DIFF
--- a/.github/workflows/issue-autocomment.yml
+++ b/.github/workflows/issue-autocomment.yml
@@ -1,0 +1,44 @@
+name: Auto Comment on Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  welcome-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Welcome new issue
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issueAuthor = context.payload.issue.user.login;
+            const issueNumber = context.payload.issue.number;
+
+            const body = `👋 Hello @${issueAuthor}, thank you for opening this issue!
+
+            We appreciate your contribution to **Innovision-Open-Source**. Here's what happens next:
+
+            ### 📋 Next Steps
+            1. A maintainer will review your issue and may add labels or ask for more details.
+            2. If you'd like to work on this issue yourself, please comment below to get assigned.
+            3. Once assigned, fork the repository and create a new branch for your changes.
+            4. Submit a Pull Request referencing this issue (e.g., \`Closes #${issueNumber}\`).
+
+            ### 📝 Guidelines
+            - Please make sure your issue has a clear **title** and **description**.
+            - Include **steps to reproduce** if reporting a bug.
+            - Check existing issues to avoid duplicates.
+
+            Thank you for helping improve this project! 🚀`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: body,
+            });

--- a/.github/workflows/pr-autocomment.yml
+++ b/.github/workflows/pr-autocomment.yml
@@ -1,0 +1,44 @@
+name: Auto Comment on Pull Requests
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  welcome-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Welcome new PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            const prNumber = context.payload.pull_request.number;
+
+            const body = `👋 Hello @${prAuthor}, thank you for submitting this Pull Request!
+
+            We appreciate your contribution to **Innovision-Open-Source**. Here's what happens next:
+
+            ### 📋 Review Process
+            1. A maintainer will review your changes as soon as possible.
+            2. You may be asked to make changes or address feedback — please watch for review comments.
+            3. Once approved, your PR will be merged into the main branch.
+
+            ### ✅ PR Checklist
+            - [ ] My code follows the project's coding style and conventions.
+            - [ ] I have tested my changes locally.
+            - [ ] I have linked the related issue (e.g., \`Closes #issue_number\`).
+            - [ ] I have added/updated documentation if needed.
+
+            Thank you for helping improve this project! 🚀`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: body,
+            });


### PR DESCRIPTION
## Summary

Closes #159 — Add GitHub Actions workflows to auto-comment on new issues and PRs.

## Changes

### `.github/workflows/issue-autocomment.yml`
- Triggers on `issues: [opened]`
- Posts a welcome comment thanking the contributor and providing next steps:
  - Wait for maintainer review/labeling
  - Comment to get assigned if they want to work on it
  - Fork, branch, and submit a PR referencing the issue number
- Includes guidelines for clear titles, reproduction steps, and duplicate checks

### `.github/workflows/pr-autocomment.yml`
- Triggers on `pull_request_target: [opened]` (uses `pull_request_target` to work with PRs from forks)
- Posts a welcome comment thanking the contributor and outlining:
  - The review process (review → feedback → merge)
  - A checklist: coding style, local testing, issue linking, documentation
- Uses `actions/github-script@v7` with minimal `pull-requests: write` permission

### Implementation Details
- Both workflows use `actions/github-script@v7` for inline JavaScript — no third-party actions needed
- Uses the built-in `GITHUB_TOKEN` — no additional secrets required
- Scoped permissions (`issues: write` / `pull-requests: write`) following least-privilege principle
- Dynamic mention of the author (`@username`) and issue/PR number in the comment body

## Files Added

| File | Purpose |
|------|---------|
| `.github/workflows/issue-autocomment.yml` | Auto-comment on new issues |
| `.github/workflows/pr-autocomment.yml` | Auto-comment on new PRs |
