### PR TITLE
fix(auth): verify JWT signature using Firebase Admin SDK (CRIT-1)

### DIFF
--- a/src/lib/auth-server.js
+++ b/src/lib/auth-server.js
@@ -1,9 +1,11 @@
 import { cookies } from "next/headers";
-import { auth as firebaseAuth } from "@/lib/firebase";
+import { getAuth } from "firebase-admin/auth";
+import "@/lib/firebase-admin"; // ensure Firebase Admin is initialized
 
 /**
- * Get the current user from the session cookie
- * This replaces NextAuth's auth() function for API routes
+ * Get the current user from the session cookie.
+ * Verifies the Firebase ID token cryptographically using the Admin SDK.
+ * This prevents forged cookies from bypassing authentication.
  */
 export async function getServerSession() {
   try {
@@ -14,24 +16,22 @@ export async function getServerSession() {
       return null;
     }
 
-    // The session cookie contains the Firebase ID token
-    // For now, we'll decode it client-side style
-    // In production, you should verify it with Firebase Admin SDK
     const idToken = sessionCookie.value;
 
-    // For now, we'll extract user info from the token payload
-    // This is a simplified approach - ideally use Firebase Admin to verify
+    // Cryptographically verify the token signature using Firebase Admin SDK.
+    // This rejects any tampered or forged tokens.
     try {
-      const payload = JSON.parse(atob(idToken.split(".")[1]));
+      const decoded = await getAuth().verifyIdToken(idToken);
       return {
         user: {
-          email: payload.email,
-          name: payload.name,
-          image: payload.picture,
+          email: decoded.email,
+          name: decoded.name,
+          image: decoded.picture,
         },
       };
     } catch (e) {
-      console.error("Failed to parse session token:", e);
+      // Token is invalid, expired, or forged — treat as unauthenticated
+      console.error("Session token verification failed:", e.message);
       return null;
     }
   } catch (error) {


### PR DESCRIPTION
## Problem
`getServerSession()` in `src/lib/auth-server.js` was decoding the JWT 
payload using `atob()` without verifying the signature. An attacker 
could craft a fake cookie with any email and fully impersonate any user.

The code even had a comment acknowledging this:
> "In production, you should verify it with Firebase Admin SDK"

## Fix
Replaced the insecure `atob()` decode with `getAuth().verifyIdToken()` 
from the Firebase Admin SDK, which cryptographically validates the token 
signature against Google's public keys.

`firebase-admin` is already installed in the project (`^13.6.0`) so no 
new dependencies are needed.

## What changed
- Removed: `import { auth as firebaseAuth } from "@/lib/firebase"`
- Removed: `JSON.parse(atob(idToken.split(".")[1]))` — no signature check
- Added: `import { getAuth } from "firebase-admin/auth"`
- Added: `getAuth().verifyIdToken(idToken)` — cryptographic verification

## Impact
Fixes complete authentication bypass (CRIT-1). Forged cookies are now 
rejected immediately.