### PR TITLE
fix: responsive dashboard - prevent overflow (bugfix/dashboard-overfl…

### DIFF
--- a/src/app/profile/page.jsx
+++ b/src/app/profile/page.jsx
@@ -179,7 +179,7 @@ export default function ProfilePage() {
           feature={blockedFeature}
         />
 
-        <div className="grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,320px)_minmax(0,1fr)] gap-6">
           {/* Left Sidebar - All original features */}
           <Sidebar
             user={userData}
@@ -190,7 +190,7 @@ export default function ProfilePage() {
           />
 
           {/* Main Content - All original tabs */}
-          <div className="space-y-6">
+          <div className="min-w-0 space-y-6">
             <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
               {/* Tab Navigation Pager (Mobile Optimized) */}
               <div className="relative group">

--- a/src/components/LeaderBoard.jsx
+++ b/src/components/LeaderBoard.jsx
@@ -7,19 +7,18 @@ import { useEffect, useState } from "react";
 const LeaderAvatar = ({ position, image, name, xp }) => {
   let size = position === 0 ? "w-16 h-16" : position === 1 ? "w-14 h-14" : position === 2 ? "w-12 h-12" : "";
   return (
-    <div className="text-center flex flex-col items-center">
+    <div className="min-w-0 text-center flex flex-col items-center">
       <div className={cn("rounded-full", size)}>
         <Avatar className={cn(size)}>
           <AvatarImage src={image} />
           <AvatarFallback>{name[0].toUpperCase()}</AvatarFallback>
         </Avatar>
       </div>
-      <div className={cn("flex gap-1 text-sm", position === 0 ? "text-lg" : position === 1 ? "text-base" : "text-sm")}>
-        {" "}
-        <span>#{position + 1}</span>
-        <p>{name.split(" ")[0]}</p>
+      <div className={cn("flex items-center justify-center gap-1 text-sm min-w-0", position === 0 ? "text-lg" : position === 1 ? "text-base" : "text-sm")}>
+        <span className="shrink-0">#{position + 1}</span>
+        <p className="truncate">{name.split(" ")[0]}</p>
       </div>
-      <p>{xp} xp</p>
+      <p className="text-xs sm:text-sm whitespace-nowrap">{xp} xp</p>
     </div>
   );
 };
@@ -36,10 +35,10 @@ const LeaderBoard = ({ leaderboard }) => {
   }, [user, leaderboard]);
 
   return (
-    <div className="p-2 border border-border shadow-sm rounded-xl">
+    <div className="w-full min-w-0 p-2 border border-border shadow-sm rounded-xl overflow-hidden">
       <h1 className="text-center">Leaderboard</h1>{" "}
       {leader[0]?.email ? (
-        <div id="head" className="flex gap-2 py-4 px-2 justify-around items-end mx-auto max-w-96">
+        <div id="head" className="grid grid-cols-3 gap-2 py-4 px-2 items-end mx-auto w-full max-w-full">
           <LeaderAvatar
             position={1}
             image={leader[1]?.image}
@@ -60,7 +59,7 @@ const LeaderBoard = ({ leaderboard }) => {
           ></LeaderAvatar>
         </div>
       ) : (
-        <div className="flex justify-around py-4 items-end mx-auto max-w-96">
+        <div className="grid grid-cols-3 gap-2 py-4 items-end mx-auto w-full max-w-full">
           <Skeleton className={"w-14 h-14 rounded-full"}></Skeleton>
           <Skeleton className={"w-16 h-16 rounded-full"}></Skeleton>
           <Skeleton className={"w-12 h-12 rounded-full"}></Skeleton>

--- a/src/components/dashboard/Sidebar.jsx
+++ b/src/components/dashboard/Sidebar.jsx
@@ -81,7 +81,7 @@ const Sidebar = ({ user, rank, difficultyLevel, leaderboard, onUserUpdate }) => 
         { icon: GlobeIcon, url: user?.socialLinks?.website, label: "Website" }
     ].filter(link => link.url && link.url.trim() !== "");
     return (
-        <div className="space-y-6 min-w-72 md:min-h-[calc(100vh-120px)] pt-3 md:sticky top-16">
+        <div className="w-full min-w-0 space-y-6 md:min-w-72 md:min-h-[calc(100vh-120px)] pt-3 md:sticky top-16">
             <Card className="gap-3">
                 <CardHeader className="pb-2">
                     <div className="flex items-center flex-wrap gap-4">

--- a/src/components/profile/StatsCard.jsx
+++ b/src/components/profile/StatsCard.jsx
@@ -114,7 +114,7 @@ export default function StatsCard({ userId }) {
 
   if (loading) {
     return (
-      <Card>
+      <Card className="min-w-0">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <TrendingUp className="h-5 w-5 text-blue-500" />
@@ -133,7 +133,7 @@ export default function StatsCard({ userId }) {
   }
 
   return (
-    <Card>
+    <Card className="min-w-0 overflow-hidden">
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           <TrendingUp className="h-5 w-5 text-blue-500" />
@@ -142,7 +142,7 @@ export default function StatsCard({ userId }) {
       </CardHeader>
       <CardContent className="space-y-6">
         {/* Stats Grid */}
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4">
           <StatItem
             icon={Clock}
             label="Hours Studied"
@@ -172,7 +172,7 @@ export default function StatsCard({ userId }) {
         </div>
 
         {/* Secondary Stats */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 min-w-0">
           <div className="text-center p-3 bg-muted rounded-lg">
             <p className="text-2xl font-bold">{stats.level}</p>
             <p className="text-xs text-muted-foreground">Level</p>
@@ -188,13 +188,13 @@ export default function StatsCard({ userId }) {
         </div>
 
         {/* Activity Heatmap */}
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
+        <div className="space-y-2 min-w-0">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between min-w-0">
             <h4 className="text-sm font-medium flex items-center gap-2">
               <Calendar className="h-4 w-4" />
               Activity Heatmap
             </h4>
-            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <div className="flex items-center gap-1 text-xs text-muted-foreground shrink-0">
               <span>Less</span>
               <div className="flex gap-0.5">
                 <div className="w-3 h-3 rounded-sm bg-muted" />
@@ -207,7 +207,7 @@ export default function StatsCard({ userId }) {
             </div>
           </div>
 
-          <div className="heatmap-container overflow-x-auto">
+          <div className="heatmap-container w-full max-w-full overflow-x-auto overflow-y-hidden pb-1">
             <CalendarHeatmap
               startDate={startDate}
               endDate={new Date()}
@@ -226,10 +226,16 @@ export default function StatsCard({ userId }) {
       <style jsx global>{`
         .heatmap-container .react-calendar-heatmap {
           font-size: 10px;
+          width: 100%;
+          min-width: 720px;
         }
         .heatmap-container .react-calendar-heatmap text {
           fill: var(--muted-foreground);
           font-size: 8px;
+        }
+        .heatmap-container .react-calendar-heatmap svg {
+          width: 100%;
+          height: auto;
         }
         .heatmap-container .react-calendar-heatmap rect {
           rx: 2;
@@ -275,11 +281,11 @@ function StatItem({ icon: Icon, label, value, suffix = "", color }) {
   };
 
   return (
-    <div className="flex flex-row sm:flex-row items-center gap-3 p-3 rounded-lg bg-muted/50">
+    <div className="min-w-0 flex flex-row items-center gap-3 p-3 rounded-lg bg-muted/50">
       <div className={`p-2 rounded-lg shrink-0 ${colorClasses[color]}`}>
         <Icon className="h-5 w-5" />
       </div>
-      <div className="min-w-0">
+      <div className="min-w-0 flex-1">
         <p className="text-lg sm:text-xl font-bold truncate">
           {value}
           {suffix && <span className="text-xs sm:text-sm font-normal text-muted-foreground ml-1">{suffix}</span>}


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #266

## Rationale for this change

The dashboard had horizontal overflow and responsiveness issues on smaller screen sizes, causing parts of the UI to become hidden.

## What changes are included in this PR?

* Fixed dashboard overflow issues
* Improved responsive layout behavior
* Added better handling for the Activity Heatmap on smaller screens
* Updated grid/flex wrapping for improved responsiveness

## Are these changes tested?

Yes. Tested manually across different screen sizes to ensure:

* no horizontal overflow
* proper card wrapping
* responsive heatmap behavior

## Are there any user-facing changes?

Yes. The dashboard UI is now more responsive and mobile-friendly.
