### PR TITLE
Show Daily Quests on the dashboard/roadmap page

### DIFF
--- a/src/app/roadmap/page.jsx
+++ b/src/app/roadmap/page.jsx
@@ -23,8 +23,11 @@ import {
 } from "@/components/ui/alert-dialog";
 import { toast } from "sonner";
 import RecommendedCourses from "@/components/RecommendedCourses";
+import DailyQuests from "@/components/gamification/DailyQuests";
+import { useAuth } from "@/contexts/auth";
 
 export default function page() {
+    const { user } = useAuth();
     const [error, setError] = useState(null);
     const [roadmaps, setRoadmaps] = useState([]);
     const [loading, setLoading] = useState(true);
@@ -236,6 +239,12 @@ export default function page() {
                 />
 
                 {!loading && !error && <RecommendedCourses query={searchQuery} />}
+
+                {!loading && !error && user?.email && (
+                    <div className="w-full max-w-4xl">
+                        <DailyQuests userId={user.email} />
+                    </div>
+                )}
 
                 {/* Search and Filter Section */}
                 {!loading && !error && completedCourses.length > 0 && (


### PR DESCRIPTION
## Fixes #264

Daily Quests were only accessible from the Profile page. This PR adds the DailyQuests component to the roadmap (home/dashboard) page so users see their active quests right on the main dashboard.

### Changes:
- Imported \DailyQuests\ and \useAuth\ in \src/app/roadmap/page.jsx\
- Rendered the DailyQuests card between RecommendedCourses and the Search/Filter section