### PR TITLE
Fix: improved courses pages

### DIFF
--- a/src/app/courses/[id]/page.jsx
+++ b/src/app/courses/[id]/page.jsx
@@ -71,6 +71,12 @@ export default function CourseDetailPage() {
     );
   }
 
+  const formatDate = (date) => {
+    if (!date) return "Date unknown";
+    const d = new Date(date);
+    return isNaN(d) ? "Date unknown" : d.toLocaleDateString();
+  };
+
   return (
     <div className="min-h-screen bg-background">
       <div className="max-w-5xl mx-auto p-6">
@@ -105,7 +111,7 @@ export default function CourseDetailPage() {
             </div>
             <div className="flex items-center gap-2">
               <Clock className="h-4 w-4" />
-              <span>Published {new Date(course.publishedAt).toLocaleDateString()}</span>
+              <span>Published {formatDate(course.publishedAt)}</span>
             </div>
           </div>
         </div>

--- a/src/app/courses/page.jsx
+++ b/src/app/courses/page.jsx
@@ -75,6 +75,12 @@ export default function CoursesPage() {
     }
   };
 
+  const formatDate = (date) => {
+    if (!date) return "Date unknown";
+    const d = new Date(date);
+    return isNaN(d) ? "Date unknown" : d.toLocaleDateString();
+  };
+
   return (
     <div className="min-h-screen bg-background relative py-10">
       <PageBackground variant="courses" />
@@ -137,7 +143,7 @@ export default function CoursesPage() {
                         </div>
                         <div className="flex items-center text-sm text-muted-foreground">
                           <Calendar className="h-4 w-4 mr-2" />
-                          <span>Published {new Date(course.publishedAt).toLocaleDateString()}</span>
+                          <span>Published {formatDate(course.publishedAt)}</span>
                         </div>
                         <Button
                           onClick={() => enrollInCourse(course)}


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #.

## Rationale for this change
The Browse Courses page (`/courses`) was completely crashing with a client-side exception because `new Date(course.publishedAt).toLocaleDateString()` was called without any null-check. If any course in Firestore has a `null`, `undefined`, or missing `publishedAt` field, this throws a runtime error inside the `.map()` and takes down the entire page render.

## What changes are included in this PR?
- Added a `formatDate` helper in `src/app/courses/page.jsx` that safely handles `null`, `undefined`, and invalid date values, returning `"Date unknown"` as a fallback
- Replaced the unsafe `new Date(course.publishedAt).toLocaleDateString()` call with `formatDate(course.publishedAt)`
- Audited `src/app/courses/[id]/page.jsx` and `src/app/courses/public/[id]/page.jsx` for the same pattern and applied the fix where applicable

## Are these changes tested?
Manually tested by setting a course's `publishedAt` field to `null` in Firestore and verifying:
- The `/courses` page loads without crashing
- Courses with a valid date display the formatted date as before
- Courses with a missing date display `"Date unknown"`

## Are there any user-facing changes?
Yes — courses with a missing published date will now display `"Date unknown"` instead of crashing the page. All other course cards are unaffected and render exactly as before.