### PR TITLE
fix(security): replace hardcoded coupon map with Firestore-backed validation 

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,7 @@ This document summarizes important security practices, immediate remediation ite
 - Use a secret manager (GCP Secret Manager / AWS Secrets Manager / Azure Key Vault) for production creds.
 - Rotate keys regularly and revoke on compromise.
 - Store `FIREBASE_PRIVATE_KEY` and other sensitive credentials in a secret store rather than a plaintext env file.
+- Treat promo codes, referral codes and partner discount tokens as credential material. Do not commit them in source. Use the Firestore-backed seeding flow at `src/scripts/seed_coupons.js`, with the source JSON kept outside the repository.
 
 ## Authentication & session management
 - Verify tokens server-side for every request that requires authentication using Firebase Admin (`getAuth().verifyIdToken()` or `getAuth().verifySessionCookie()`).

--- a/src/app/api/premium/create-order/route.js
+++ b/src/app/api/premium/create-order/route.js
@@ -1,42 +1,30 @@
 import { NextResponse } from "next/server";
 import { getServerSession } from "@/lib/auth-server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { validateAndReserveCoupon, computeDiscountPaise } from "@/lib/coupons";
 import Razorpay from "razorpay";
 import { z } from "zod";
 
-// Secret coupons - don't expose these publicly
-const COUPONS = {
-  VICKY1: { discount: 100, type: "percent" }, // 100% off = FREE
-  SANJANA04: { discount: 100, type: "percent" }, // FREE
-  VILAS16: { discount: 100, type: "percent" }, // FREE
-  BHUMI07: { discount: 100, type: "percent" }, // FREE
-  SNEHA07: { discount: 100, type: "percent" }, // FREE
-  SANIYA07: { discount: 100, type: "percent" }, // FREE
-  RAKESH01: { discount: 100, type: "percent" }, // FREE
-  VICKY15: { discount: 15, type: "percent" },
-  VICKY20: { discount: 20, type: "percent" },
-  VICKY50: { discount: 50, type: "percent" },
-  LAUNCH10: { discount: 10, type: "percent" },
-  STUDENT25: { discount: 25, type: "percent" },
+const PLAN_AMOUNTS = {
+  premium: 10000,
+  education: 5000,
 };
+
+const orderSchema = z.object({
+  planType: z.enum(["premium", "education"]).default("premium"),
+  couponCode: z.string().optional().nullable(),
+});
 
 export async function POST(req) {
   try {
-    // Check if Razorpay keys are configured
     if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
-      console.error("Razorpay keys not configured");
       return NextResponse.json(
         { error: "Payment gateway not configured", details: "Missing Razorpay API keys" },
         { status: 500 }
       );
     }
 
-    const razorpay = new Razorpay({
-      key_id: process.env.RAZORPAY_KEY_ID,
-      key_secret: process.env.RAZORPAY_KEY_SECRET,
-    });
-
     const session = await getServerSession();
-
     if (!session?.user) {
       return NextResponse.json(
         { error: "Unauthorized", details: "Please login to continue" },
@@ -44,61 +32,57 @@ export async function POST(req) {
       );
     }
 
-    // Get plan type and coupon from request body
-    const body = await req.json();
-
-    // Define validation schema
-    const orderSchema = z.object({
-      planType: z.enum(["premium", "education"]).default("premium"),
-      couponCode: z.string().optional().nullable(),
-    });
-
-    const result = orderSchema.safeParse(body);
-
-    if (!result.success) {
+    const parsed = orderSchema.safeParse(await req.json());
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: "Invalid input", details: result.error.format() },
+        { error: "Invalid input", details: parsed.error.format() },
         { status: 400 }
       );
     }
 
-    const { planType, couponCode: rawCoupon } = result.data;
-    const couponCode = rawCoupon?.toUpperCase()?.trim() || null;
+    const { planType } = parsed.data;
+    const couponCode = parsed.data.couponCode?.toUpperCase()?.trim() || null;
+    const baseAmount = PLAN_AMOUNTS[planType];
 
-    // Set base amount based on plan type
-    // Premium: ₹100 (10000 paise)
-    // Education: ₹50 (5000 paise) - 50% off
-    let baseAmount = planType === "education" ? 5000 : 10000;
-    let discountApplied = 0;
     let couponValid = false;
+    let discountApplied = 0;
 
-    // Apply coupon if provided
-    if (couponCode && COUPONS[couponCode]) {
-      const coupon = COUPONS[couponCode];
-      if (coupon.type === "percent") {
-        discountApplied = Math.round((baseAmount * coupon.discount) / 100);
-      } else {
-        discountApplied = coupon.discount * 100; // Convert to paise
+    if (couponCode) {
+      const adminDb = getAdminDb();
+      if (!adminDb) {
+        return NextResponse.json(
+          { error: "Coupon validation unavailable", details: "Database not initialized" },
+          { status: 503 }
+        );
       }
-      couponValid = true;
+
+      const result = await validateAndReserveCoupon(adminDb, couponCode, session.user.email);
+      if (result.valid) {
+        couponValid = true;
+        discountApplied = computeDiscountPaise(baseAmount, result.coupon);
+      }
     }
 
-    const finalAmount = Math.max(baseAmount - discountApplied, 100); // Minimum ₹1
+    const finalAmount = Math.max(baseAmount - discountApplied, 100);
     const planLabel = planType === "education" ? "edu" : "prem";
-
-    // Receipt must be max 40 characters
     const receipt = `${planLabel}_${Date.now()}`;
+
+    const razorpay = new Razorpay({
+      key_id: process.env.RAZORPAY_KEY_ID,
+      key_secret: process.env.RAZORPAY_KEY_SECRET,
+    });
+
     const order = await razorpay.orders.create({
       amount: finalAmount,
       currency: "INR",
-      receipt: receipt,
+      receipt,
       notes: {
         email: session.user.email,
         type: planType === "education" ? "education_subscription" : "premium_subscription",
-        planType: planType,
-        couponCode: couponCode || "none",
+        planType,
+        couponCode: couponValid ? couponCode : "none",
         originalAmount: baseAmount,
-        discountApplied: discountApplied,
+        discountApplied,
       },
     });
 
@@ -106,14 +90,14 @@ export async function POST(req) {
       orderId: order.id,
       amount: order.amount,
       originalAmount: baseAmount,
-      discountApplied: discountApplied,
-      couponValid: couponValid,
+      discountApplied,
+      couponValid,
       currency: order.currency,
       keyId: process.env.NEXT_PUBLIC_RAZORPAY_KEY_ID,
-      planType: planType,
+      planType,
     });
   } catch (error) {
-    console.error("Error creating Razorpay order:", error.message, error);
+    console.error("Error creating Razorpay order:", error.message);
     return NextResponse.json(
       { error: "Failed to create order", details: error.message || "Unknown error" },
       { status: 500 }

--- a/src/app/api/premium/create-order/route.test.js
+++ b/src/app/api/premium/create-order/route.test.js
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth-server", () => ({
+  getServerSession: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: vi.fn(),
+  FieldValue: {
+    increment: (n) => ({ __op: "increment", value: n }),
+  },
+}));
+
+vi.mock("razorpay", () => ({
+  default: class MockRazorpay {
+    constructor() {}
+    get orders() {
+      return {
+        create: vi.fn(async (opts) => ({
+          id: "order_test_id",
+          amount: opts.amount,
+          currency: opts.currency,
+        })),
+      };
+    }
+  },
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+    }),
+  },
+}));
+
+import { getServerSession } from "@/lib/auth-server";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { POST } from "./route.js";
+
+function makeReq(body) {
+  return { json: async () => body };
+}
+
+function makeDb({ exists = true, data = {} } = {}) {
+  const snap = { exists, data: () => data };
+  const couponRef = {};
+  return {
+    collection: vi.fn(() => ({ doc: vi.fn(() => couponRef) })),
+    runTransaction: vi.fn(async (cb) =>
+      cb({
+        get: vi.fn(async () => snap),
+        update: vi.fn(),
+      })
+    ),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  process.env.RAZORPAY_KEY_ID = "rzp_test_x";
+  process.env.RAZORPAY_KEY_SECRET = "secret_x";
+  process.env.NEXT_PUBLIC_RAZORPAY_KEY_ID = "rzp_test_x";
+  getServerSession.mockResolvedValue({ user: { email: "user@example.com" } });
+});
+
+describe("POST /api/premium/create-order", () => {
+  it("returns 401 when no session", async () => {
+    getServerSession.mockResolvedValue(null);
+    const res = await POST(makeReq({ planType: "premium" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when planType is invalid", async () => {
+    const res = await POST(makeReq({ planType: "invalid" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a premium order without a coupon and does not touch the database", async () => {
+    const res = await POST(makeReq({ planType: "premium" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.couponValid).toBe(false);
+    expect(body.discountApplied).toBe(0);
+    expect(body.amount).toBe(10000);
+    expect(getAdminDb).not.toHaveBeenCalled();
+  });
+
+  it("applies a valid percent coupon and reserves it", async () => {
+    const db = makeDb({
+      exists: true,
+      data: {
+        discount: 50,
+        type: "percent",
+        active: true,
+        validFrom: null,
+        validUntil: null,
+        maxUses: null,
+        allowedEmails: [],
+        usesCount: 0,
+        reservedCount: 0,
+      },
+    });
+    getAdminDb.mockReturnValue(db);
+
+    const res = await POST(makeReq({ planType: "premium", couponCode: "half" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.couponValid).toBe(true);
+    expect(body.discountApplied).toBe(5000);
+    expect(body.amount).toBe(5000);
+    expect(db.runTransaction).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a coupon whose document does not exist", async () => {
+    getAdminDb.mockReturnValue(makeDb({ exists: false }));
+    const res = await POST(makeReq({ planType: "premium", couponCode: "GHOST" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.couponValid).toBe(false);
+    expect(body.discountApplied).toBe(0);
+  });
+
+  it("rejects an inactive coupon", async () => {
+    getAdminDb.mockReturnValue(
+      makeDb({
+        exists: true,
+        data: { discount: 100, type: "percent", active: false },
+      })
+    );
+    const res = await POST(makeReq({ planType: "premium", couponCode: "DEAD" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).couponValid).toBe(false);
+  });
+
+  it("rejects an expired coupon", async () => {
+    const past = new Date(Date.now() - 86400000);
+    getAdminDb.mockReturnValue(
+      makeDb({
+        exists: true,
+        data: {
+          discount: 100,
+          type: "percent",
+          active: true,
+          validUntil: { toDate: () => past },
+        },
+      })
+    );
+    const res = await POST(makeReq({ planType: "premium", couponCode: "OLD" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).couponValid).toBe(false);
+  });
+
+  it("rejects a coupon whose start date has not yet arrived", async () => {
+    const future = new Date(Date.now() + 86400000);
+    getAdminDb.mockReturnValue(
+      makeDb({
+        exists: true,
+        data: {
+          discount: 100,
+          type: "percent",
+          active: true,
+          validFrom: { toDate: () => future },
+        },
+      })
+    );
+    const res = await POST(makeReq({ planType: "premium", couponCode: "EARLY" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).couponValid).toBe(false);
+  });
+
+  it("rejects an exhausted coupon (reservedCount + usesCount >= maxUses)", async () => {
+    getAdminDb.mockReturnValue(
+      makeDb({
+        exists: true,
+        data: {
+          discount: 100,
+          type: "percent",
+          active: true,
+          maxUses: 1,
+          usesCount: 0,
+          reservedCount: 1,
+        },
+      })
+    );
+    const res = await POST(makeReq({ planType: "premium", couponCode: "USED" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).couponValid).toBe(false);
+  });
+
+  it("rejects an email-restricted coupon for a non-allowed user", async () => {
+    getAdminDb.mockReturnValue(
+      makeDb({
+        exists: true,
+        data: {
+          discount: 100,
+          type: "percent",
+          active: true,
+          allowedEmails: ["someone@else.com"],
+        },
+      })
+    );
+    const res = await POST(makeReq({ planType: "premium", couponCode: "PRIV" }));
+    expect(res.status).toBe(200);
+    expect((await res.json()).couponValid).toBe(false);
+  });
+
+  it("accepts an email-restricted coupon for an allowed user", async () => {
+    getAdminDb.mockReturnValue(
+      makeDb({
+        exists: true,
+        data: {
+          discount: 25,
+          type: "percent",
+          active: true,
+          allowedEmails: ["user@example.com"],
+          usesCount: 0,
+          reservedCount: 0,
+        },
+      })
+    );
+    const res = await POST(makeReq({ planType: "premium", couponCode: "PRIV" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.couponValid).toBe(true);
+    expect(body.discountApplied).toBe(2500);
+  });
+
+  it("clamps the final amount to at least 100 paise on full discount", async () => {
+    getAdminDb.mockReturnValue(
+      makeDb({
+        exists: true,
+        data: {
+          discount: 100,
+          type: "percent",
+          active: true,
+          usesCount: 0,
+          reservedCount: 0,
+        },
+      })
+    );
+    const res = await POST(makeReq({ planType: "premium", couponCode: "FREE" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.discountApplied).toBe(10000);
+    expect(body.amount).toBe(100);
+  });
+
+  it("returns 503 when the admin database is not initialized and a coupon was supplied", async () => {
+    getAdminDb.mockReturnValue(null);
+    const res = await POST(makeReq({ planType: "premium", couponCode: "ANY" }));
+    expect(res.status).toBe(503);
+  });
+
+  it("computes the correct base amount for the education plan", async () => {
+    const res = await POST(makeReq({ planType: "education" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.amount).toBe(5000);
+  });
+});

--- a/src/app/api/premium/verify-payment/route.js
+++ b/src/app/api/premium/verify-payment/route.js
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { getServerSession } from "@/lib/auth-server";
+import { getAdminDb } from "@/lib/firebase-admin";
 import { activatePremium } from "@/lib/premium";
+import { consumeCoupon } from "@/lib/coupons";
+import Razorpay from "razorpay";
 import crypto from "crypto";
 
 export async function POST(req) {
@@ -13,11 +16,9 @@ export async function POST(req) {
 
     const { razorpay_order_id, razorpay_payment_id, razorpay_signature } = await req.json();
 
-    // Verify signature
-    const body = razorpay_order_id + "|" + razorpay_payment_id;
     const expectedSignature = crypto
       .createHmac("sha256", process.env.RAZORPAY_KEY_SECRET)
-      .update(body.toString())
+      .update(`${razorpay_order_id}|${razorpay_payment_id}`)
       .digest("hex");
 
     if (expectedSignature !== razorpay_signature) {
@@ -27,7 +28,6 @@ export async function POST(req) {
       );
     }
 
-    // Activate premium for 1 month
     const success = await activatePremium(session.user.email, 1, razorpay_payment_id);
 
     if (!success) {
@@ -35,6 +35,21 @@ export async function POST(req) {
         { error: "Failed to activate premium" },
         { status: 500 }
       );
+    }
+
+    try {
+      const razorpay = new Razorpay({
+        key_id: process.env.RAZORPAY_KEY_ID,
+        key_secret: process.env.RAZORPAY_KEY_SECRET,
+      });
+      const order = await razorpay.orders.fetch(razorpay_order_id);
+      const couponCode = order?.notes?.couponCode;
+      const adminDb = getAdminDb();
+      if (adminDb && couponCode && couponCode !== "none") {
+        await consumeCoupon(adminDb, couponCode);
+      }
+    } catch (couponError) {
+      console.error("Coupon consumption failed (non-blocking):", couponError.message);
     }
 
     return NextResponse.json({

--- a/src/lib/coupons.js
+++ b/src/lib/coupons.js
@@ -1,0 +1,66 @@
+import { FieldValue } from "@/lib/firebase-admin";
+
+export async function validateAndReserveCoupon(adminDb, couponCode, userEmail) {
+  if (!couponCode) return { valid: false, coupon: null };
+
+  const couponRef = adminDb.collection("coupons").doc(couponCode);
+
+  return await adminDb.runTransaction(async (transaction) => {
+    const snap = await transaction.get(couponRef);
+    if (!snap.exists) return { valid: false, coupon: null };
+
+    const data = snap.data();
+    const now = new Date();
+
+    if (data.active === false) return { valid: false, coupon: null };
+
+    if (data.validFrom && typeof data.validFrom.toDate === "function" && now < data.validFrom.toDate()) {
+      return { valid: false, coupon: null };
+    }
+
+    if (data.validUntil && typeof data.validUntil.toDate === "function" && now > data.validUntil.toDate()) {
+      return { valid: false, coupon: null };
+    }
+
+    const totalUsed = (data.usesCount || 0) + (data.reservedCount || 0);
+    if (typeof data.maxUses === "number" && totalUsed >= data.maxUses) {
+      return { valid: false, coupon: null };
+    }
+
+    const allowed = data.allowedEmails;
+    if (Array.isArray(allowed) && allowed.length > 0 && !allowed.includes(userEmail)) {
+      return { valid: false, coupon: null };
+    }
+
+    transaction.update(couponRef, { reservedCount: FieldValue.increment(1) });
+
+    return {
+      valid: true,
+      coupon: { discount: data.discount, type: data.type },
+    };
+  });
+}
+
+export async function consumeCoupon(adminDb, couponCode) {
+  if (!couponCode || couponCode === "none") return;
+
+  const couponRef = adminDb.collection("coupons").doc(couponCode);
+
+  await adminDb.runTransaction(async (transaction) => {
+    const snap = await transaction.get(couponRef);
+    if (!snap.exists) return;
+
+    transaction.update(couponRef, {
+      usesCount: FieldValue.increment(1),
+      reservedCount: FieldValue.increment(-1),
+    });
+  });
+}
+
+export function computeDiscountPaise(baseAmount, coupon) {
+  if (!coupon) return 0;
+  if (coupon.type === "percent") {
+    return Math.round((baseAmount * coupon.discount) / 100);
+  }
+  return Math.round(coupon.discount * 100);
+}

--- a/src/scripts/seed_coupons.js
+++ b/src/scripts/seed_coupons.js
@@ -1,0 +1,88 @@
+import "dotenv/config";
+import { readFileSync } from "fs";
+import { adminDb, FieldValue } from "../lib/firebase-admin.js";
+
+async function seedCoupons() {
+  const inputPath = process.argv[2];
+  if (!inputPath) {
+    console.error("Usage: node src/scripts/seed_coupons.js <path-to-coupons.json>");
+    console.error("The JSON file must NOT be committed. Keep it outside the repo.");
+    process.exit(1);
+  }
+
+  if (!adminDb) {
+    console.error("Firebase Admin not initialized. Set FIREBASE_PROJECT_ID, FIREBASE_CLIENT_EMAIL, and FIREBASE_PRIVATE_KEY.");
+    process.exit(1);
+  }
+
+  let coupons;
+  try {
+    coupons = JSON.parse(readFileSync(inputPath, "utf8"));
+  } catch (err) {
+    console.error(`Failed to read or parse ${inputPath}:`, err.message);
+    process.exit(1);
+  }
+
+  if (!Array.isArray(coupons)) {
+    console.error("Input JSON must be an array of coupon objects.");
+    process.exit(1);
+  }
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const c of coupons) {
+    if (!c.code || typeof c.code !== "string") {
+      console.warn("Skipping entry without valid 'code' string:", c);
+      skipped += 1;
+      continue;
+    }
+    if (typeof c.discount !== "number" || c.discount <= 0) {
+      console.warn(`Skipping ${c.code}: 'discount' must be a positive number`);
+      skipped += 1;
+      continue;
+    }
+    if (c.type !== "percent" && c.type !== "flat") {
+      console.warn(`Skipping ${c.code}: 'type' must be 'percent' or 'flat'`);
+      skipped += 1;
+      continue;
+    }
+
+    const code = c.code.toUpperCase().trim();
+    const docRef = adminDb.collection("coupons").doc(code);
+    const existing = await docRef.get();
+
+    const payload = {
+      discount: c.discount,
+      type: c.type,
+      validFrom: c.validFrom ? new Date(c.validFrom) : null,
+      validUntil: c.validUntil ? new Date(c.validUntil) : null,
+      maxUses: typeof c.maxUses === "number" ? c.maxUses : null,
+      allowedEmails: Array.isArray(c.allowedEmails) ? c.allowedEmails : [],
+      active: c.active !== false,
+    };
+
+    if (!existing.exists) {
+      payload.usesCount = 0;
+      payload.reservedCount = 0;
+      payload.createdAt = FieldValue.serverTimestamp();
+      await docRef.set(payload);
+      created += 1;
+      console.log(`Created: ${code}`);
+    } else {
+      payload.updatedAt = FieldValue.serverTimestamp();
+      await docRef.set(payload, { merge: true });
+      updated += 1;
+      console.log(`Updated: ${code}`);
+    }
+  }
+
+  console.log(`Done. Created ${created}, updated ${updated}, skipped ${skipped}.`);
+  process.exit(0);
+}
+
+seedCoupons().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
# Closes #276.

## What changed

- Removed the hardcoded `COUPONS` map from `src/app/api/premium/create-order/route.js`.
- Added `src/lib/coupons.js` with two transactional helpers and one pure utility.
- `create-order` now validates and reserves a coupon inside a Firestore transaction.
- `verify-payment` consumes the reservation only after the Razorpay signature is verified, by fetching the order's `notes.couponCode` from Razorpay (server source of truth, not client input).
- `src/scripts/seed_coupons.js` reads a JSON file path from argv and upserts the `coupons` collection. The source JSON is meant to live outside the repo.
- `SECURITY.md` updated under "Secrets & environment" to treat promo codes as credential material.
- 14 vitest cases for `create-order` covering happy path, no coupon, missing doc, inactive, expired, not-yet-valid, exhausted, email-restricted (both directions), full-discount clamp, education plan, auth, validation, and DB unavailability.

## Firestore schema (per coupon doc, ID is the uppercase code)

```txt
discount: number
type: "percent" | "flat"
validFrom: Timestamp | null
validUntil: Timestamp | null
maxUses: number | null
usesCount: number
reservedCount: number
allowedEmails: string[]
active: boolean
createdAt / updatedAt: serverTimestamp
```

## Concurrency

`create-order` increments `reservedCount` inside a transaction. `verify-payment` decrements `reservedCount` and increments `usesCount` inside another transaction. The exhaustion check is `usesCount + reservedCount >= maxUses`, so two simultaneous redemptions of a `maxUses: 1` coupon cannot both succeed.

## Maintainer action required after merge

1. Run the seed script with a JSON file kept outside the repo:

```bash
node src/scripts/seed_coupons.js /path/to/coupons.json
```

2. Do NOT re-seed the seven 100 percent off codes (`VICKY1`, `SANJANA04`, `VILAS16`, `BHUMI07`, `SNEHA07`, `SANIYA07`, `RAKESH01`). Treat them as compromised. Issue fresh codes out of band to the original recipients if needed.

3. The frontend at `src/app/premium/page.jsx` was intentionally not changed. The API response shape is preserved.

## Known limitations (intentionally out of scope, follow-up issues recommended)

- Stale reservations from abandoned checkouts (`reservedCount` not decremented if Razorpay is closed without paying) will accumulate. A scheduled cleanup task is the proper fix.
- `verify-payment` still lacks idempotency on `razorpay_payment_id`. Replaying a valid signature stacks subscription months. Tracking separately.
- No Razorpay webhook handler for server-side reconciliation.

## Test plan

- `npm install` (the test file relies on the existing happy-dom and vitest setup, no new dev dependencies).
- `npm run test` to execute the new test file alongside the existing one.
- Manual test against a Firestore project: seed two coupons (one valid percent, one inactive), call `/api/premium/create-order` with each, verify response shapes and the document counters.