### PR TITLE
fix(security): gate /api/research/export behind admin auth, HMAC pseudo IDs, pagination, rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ GEMINI_API_KEY=your-gemini-api-key
 RAZORPAY_KEY_ID=rzp_test_xxxxx
 RAZORPAY_KEY_SECRET=your-razorpay-key-secret
 NEXT_PUBLIC_RAZORPAY_KEY_ID=rzp_test_xxxxx
+
+RESEARCH_HASH_SECRET=replace-with-a-long-random-string-and-rotate-on-compromise
 NEXT_PUBLIC_EMAILJS_SERVICE_ID=your-service-id
 NEXT_PUBLIC_EMAILJS_TEMPLATE_ID=your-template-id
 NEXT_PUBLIC_EMAILJS_USER_ID=your-user-id

--- a/src/app/api/research/export/route.js
+++ b/src/app/api/research/export/route.js
@@ -1,57 +1,45 @@
 import { NextResponse } from "next/server";
-import { adminDb } from "@/lib/firebase-admin";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { assertAdmin, AuthError } from "@/lib/auth-server";
+import { checkRateLimit } from "@/lib/rate-limit";
 import crypto from "crypto";
 
-export async function GET(request) {
-  try {
-    const { searchParams } = new URL(request.url);
-    const type = searchParams.get("type");
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 500;
 
-    if (type === "interactions") {
-      return await exportInteractions();
-    } else if (type === "outcomes") {
-      return await exportOutcomes();
-    }
+function hashUserId(userId, secret) {
+  return crypto.createHmac("sha256", secret).update(userId).digest("hex").substring(0, 16);
+}
 
-    return NextResponse.json({ error: "Invalid type" }, { status: 400 });
-  } catch (error) {
-    console.error("Export error:", error);
-    return NextResponse.json({ error: "Export failed" }, { status: 500 });
+function roundTimestamp(timestamp) {
+  if (!timestamp) return null;
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) return null;
+  date.setUTCMinutes(0, 0, 0);
+  return date.toISOString();
+}
+
+function parseLimit(raw) {
+  const n = parseInt(raw || "", 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(n, MAX_LIMIT);
+}
+
+async function fetchPage(adminDb, collectionName, limit, cursor) {
+  const { FieldPath } = await import("firebase-admin/firestore");
+  let query = adminDb.collection(collectionName).orderBy(FieldPath.documentId()).limit(limit);
+  if (cursor) {
+    query = query.startAfter(cursor);
   }
+  const snapshot = await query.get();
+  return snapshot.docs;
 }
 
-async function exportInteractions() {
-  // Get all user activity data
-  const snapshot = await adminDb.collection("user_activity").get();
-
-  const anonymizedData = snapshot.docs.map((doc) => {
+function mapOutcomes(docs, secret) {
+  return docs.map((doc) => {
     const data = doc.data();
     return {
-      userId: hashUserId(data.userId || doc.id),
-      action: data.action,
-      timestamp: roundTimestamp(data.timestamp),
-      duration: data.duration,
-      courseId: data.courseId,
-      chapterId: data.chapterId,
-    };
-  });
-
-  return new NextResponse(JSON.stringify(anonymizedData, null, 2), {
-    headers: {
-      "Content-Type": "application/json",
-      "Content-Disposition": "attachment; filename=interactions.json",
-    },
-  });
-}
-
-async function exportOutcomes() {
-  // Get gamification stats (outcomes)
-  const snapshot = await adminDb.collection("gamification").get();
-
-  const anonymizedData = snapshot.docs.map((doc) => {
-    const data = doc.data();
-    return {
-      userId: hashUserId(doc.id),
+      userId: hashUserId(doc.id, secret),
       xp: data.xp,
       level: data.level,
       streak: data.streak,
@@ -60,22 +48,88 @@ async function exportOutcomes() {
       lastActive: roundTimestamp(data.lastActive),
     };
   });
+}
 
-  return new NextResponse(JSON.stringify(anonymizedData, null, 2), {
-    headers: {
-      "Content-Type": "application/json",
-      "Content-Disposition": "attachment; filename=outcomes.json",
-    },
+function mapInteractions(docs, secret) {
+  return docs.map((doc) => {
+    const data = doc.data();
+    return {
+      userId: hashUserId(data.userId || doc.id, secret),
+      action: data.action,
+      timestamp: roundTimestamp(data.timestamp),
+      duration: data.duration,
+      courseId: data.courseId,
+      chapterId: data.chapterId,
+    };
   });
 }
 
-function hashUserId(userId) {
-  return crypto.createHash("sha256").update(userId).digest("hex").substring(0, 16);
-}
+export async function GET(request) {
+  let decoded;
+  try {
+    decoded = await assertAdmin();
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
+    }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-function roundTimestamp(timestamp) {
-  if (!timestamp) return null;
-  const date = new Date(timestamp);
-  date.setMinutes(0, 0, 0);
-  return date.toISOString();
+  const rateKey = `research-export:${decoded.uid || decoded.email || "unknown"}`;
+  const rate = checkRateLimit(rateKey, { limit: 30, windowMs: 60 * 1000 });
+  if (!rate.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests" },
+      {
+        status: 429,
+        headers: {
+          "Retry-After": String(Math.ceil(rate.retryAfterMs / 1000)),
+        },
+      }
+    );
+  }
+
+  const secret = process.env.RESEARCH_HASH_SECRET;
+  if (!secret) {
+    console.error("RESEARCH_HASH_SECRET is not configured");
+    return NextResponse.json(
+      { error: "Research export is not configured" },
+      { status: 503 }
+    );
+  }
+
+  const adminDb = getAdminDb();
+  if (!adminDb) {
+    return NextResponse.json(
+      { error: "Database is not initialized" },
+      { status: 503 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const type = searchParams.get("type");
+  const cursor = searchParams.get("cursor");
+  const limit = parseLimit(searchParams.get("limit"));
+
+  let collectionName;
+  let mapper;
+  if (type === "interactions") {
+    collectionName = "user_activity";
+    mapper = mapInteractions;
+  } else if (type === "outcomes") {
+    collectionName = "gamification";
+    mapper = mapOutcomes;
+  } else {
+    return NextResponse.json({ error: "Invalid type" }, { status: 400 });
+  }
+
+  try {
+    const docs = await fetchPage(adminDb, collectionName, limit, cursor);
+    const data = mapper(docs, secret);
+    const nextCursor = docs.length === limit ? docs[docs.length - 1].id : null;
+    return NextResponse.json({ data, nextCursor });
+  } catch (error) {
+    console.error("Export error:", error);
+    return NextResponse.json({ error: "Export failed" }, { status: 500 });
+  }
 }

--- a/src/app/api/research/export/route.test.js
+++ b/src/app/api/research/export/route.test.js
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  cookies: vi.fn(),
+}));
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: vi.fn(),
+}));
+
+vi.mock("firebase-admin/firestore", () => ({
+  FieldPath: { documentId: () => "__name__" },
+}));
+
+vi.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: vi.fn(),
+  FieldValue: { increment: (n) => ({ __op: "increment", value: n }) },
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  auth: {},
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+      headers: init?.headers || {},
+    }),
+  },
+}));
+
+import { cookies } from "next/headers";
+import { getAuth } from "firebase-admin/auth";
+import { getAdminDb } from "@/lib/firebase-admin";
+import { clearAllRateLimits } from "@/lib/rate-limit";
+import { GET } from "./route.js";
+
+function makeReq(url) {
+  return { url };
+}
+
+function makeCookiesWith(sessionValue) {
+  return {
+    get: vi.fn((name) => (name === "session" && sessionValue ? { value: sessionValue } : undefined)),
+  };
+}
+
+function makeDocs(items) {
+  return items.map((entry) => ({
+    id: entry.id,
+    data: () => entry.data,
+  }));
+}
+
+function makeDb(docs) {
+  const query = {
+    orderBy: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    startAfter: vi.fn().mockReturnThis(),
+    get: vi.fn(async () => ({ docs })),
+  };
+  return {
+    collection: vi.fn(() => query),
+    _query: query,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearAllRateLimits();
+  process.env.RESEARCH_HASH_SECRET = "test-secret";
+});
+
+describe("GET /api/research/export", () => {
+  it("returns 401 when no session cookie is present", async () => {
+    cookies.mockResolvedValue(makeCookiesWith(null));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(),
+      verifyIdToken: vi.fn(),
+    });
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when both verifySessionCookie and verifyIdToken throw", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("bad-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => {
+        throw new Error("bad cookie");
+      }),
+      verifyIdToken: vi.fn(async () => {
+        throw new Error("bad id token");
+      }),
+    });
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when verified token does not have admin custom claim", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: false })),
+      verifyIdToken: vi.fn(),
+    });
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes"));
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 for an unknown type", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    getAdminDb.mockReturnValue(makeDb([]));
+    const res = await GET(makeReq("https://x.test/api/research/export?type=nope"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 503 when RESEARCH_HASH_SECRET is missing", async () => {
+    delete process.env.RESEARCH_HASH_SECRET;
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes"));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 503 when admin db is not initialized", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    getAdminDb.mockReturnValue(null);
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes"));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 200 with paginated outcomes data and HMAC pseudo IDs", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    const docs = makeDocs([
+      {
+        id: "alice@example.com",
+        data: {
+          xp: 100,
+          level: 2,
+          streak: 5,
+          badges: ["a", "b"],
+          achievements: ["x"],
+          lastActive: "2026-05-19T12:34:56.000Z",
+        },
+      },
+      {
+        id: "bob@example.com",
+        data: {
+          xp: 50,
+          level: 1,
+          streak: 1,
+          badges: [],
+          achievements: [],
+          lastActive: "2026-05-18T09:00:00.000Z",
+        },
+      },
+    ]);
+    getAdminDb.mockReturnValue(makeDb(docs));
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes&limit=2"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].userId).toHaveLength(16);
+    expect(body.data[0].userId).not.toBe("alice@example.com");
+    expect(body.data[0].xp).toBe(100);
+    expect(body.data[0].badgesCount).toBe(2);
+    expect(body.data[0].lastActive).toBe("2026-05-19T12:00:00.000Z");
+    expect(body.nextCursor).toBe("bob@example.com");
+  });
+
+  it("returns nextCursor null when results are below the requested limit", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    const docs = makeDocs([
+      { id: "only@example.com", data: { xp: 1, level: 1, streak: 1 } },
+    ]);
+    getAdminDb.mockReturnValue(makeDb(docs));
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes&limit=50"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.nextCursor).toBeNull();
+  });
+
+  it("HMAC pseudo IDs differ when the secret differs", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    const docs = makeDocs([{ id: "alice@example.com", data: { xp: 1 } }]);
+    getAdminDb.mockReturnValue(makeDb(docs));
+
+    process.env.RESEARCH_HASH_SECRET = "secret-a";
+    let res = await GET(makeReq("https://x.test/api/research/export?type=outcomes&limit=10"));
+    const idA = (await res.json()).data[0].userId;
+
+    process.env.RESEARCH_HASH_SECRET = "secret-b";
+    res = await GET(makeReq("https://x.test/api/research/export?type=outcomes&limit=10"));
+    const idB = (await res.json()).data[0].userId;
+
+    expect(idA).not.toBe(idB);
+  });
+
+  it("returns 429 after the rate limit threshold is exceeded", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    getAdminDb.mockReturnValue(makeDb([]));
+
+    let lastStatus = 0;
+    for (let i = 0; i < 31; i += 1) {
+      const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes"));
+      lastStatus = res.status;
+    }
+    expect(lastStatus).toBe(429);
+  });
+
+  it("falls back to verifyIdToken when verifySessionCookie throws", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("legacy-id-token"));
+    const verifySessionCookie = vi.fn(async () => {
+      throw new Error("not a session cookie");
+    });
+    const verifyIdToken = vi.fn(async () => ({ uid: "u1", admin: true }));
+    getAuth.mockReturnValue({ verifySessionCookie, verifyIdToken });
+    getAdminDb.mockReturnValue(makeDb([]));
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes"));
+    expect(res.status).toBe(200);
+    expect(verifySessionCookie).toHaveBeenCalled();
+    expect(verifyIdToken).toHaveBeenCalled();
+  });
+
+  it("clamps a too-large limit down to MAX_LIMIT", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    const db = makeDb([]);
+    getAdminDb.mockReturnValue(db);
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes&limit=9999"));
+    expect(res.status).toBe(200);
+    expect(db._query.limit).toHaveBeenCalledWith(500);
+  });
+
+  it("passes a cursor to startAfter when provided", async () => {
+    cookies.mockResolvedValue(makeCookiesWith("ok-token"));
+    getAuth.mockReturnValue({
+      verifySessionCookie: vi.fn(async () => ({ uid: "u1", admin: true })),
+      verifyIdToken: vi.fn(),
+    });
+    const db = makeDb([]);
+    getAdminDb.mockReturnValue(db);
+    const res = await GET(makeReq("https://x.test/api/research/export?type=outcomes&cursor=zzz@example.com"));
+    expect(res.status).toBe(200);
+    expect(db._query.startAfter).toHaveBeenCalledWith("zzz@example.com");
+  });
+});

--- a/src/lib/auth-server.js
+++ b/src/lib/auth-server.js
@@ -1,10 +1,14 @@
 import { cookies } from "next/headers";
 import { auth as firebaseAuth } from "@/lib/firebase";
 
-/**
- * Get the current user from the session cookie
- * This replaces NextAuth's auth() function for API routes
- */
+export class AuthError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.name = "AuthError";
+    this.status = status;
+  }
+}
+
 export async function getServerSession() {
   try {
     const cookieStore = await cookies();
@@ -14,13 +18,8 @@ export async function getServerSession() {
       return null;
     }
 
-    // The session cookie contains the Firebase ID token
-    // For now, we'll decode it client-side style
-    // In production, you should verify it with Firebase Admin SDK
     const idToken = sessionCookie.value;
 
-    // For now, we'll extract user info from the token payload
-    // This is a simplified approach - ideally use Firebase Admin to verify
     try {
       const payload = JSON.parse(atob(idToken.split(".")[1]));
       return {
@@ -38,4 +37,32 @@ export async function getServerSession() {
     console.error("Error getting server session:", error);
     return null;
   }
+}
+
+export async function assertAdmin() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get("session")?.value;
+  if (!session) {
+    throw new AuthError("Unauthorized", 401);
+  }
+
+  const { getAuth } = await import("firebase-admin/auth");
+  const auth = getAuth();
+
+  let decoded;
+  try {
+    decoded = await auth.verifySessionCookie(session, true);
+  } catch (_) {
+    try {
+      decoded = await auth.verifyIdToken(session, true);
+    } catch (_) {
+      throw new AuthError("Unauthorized", 401);
+    }
+  }
+
+  if (decoded.admin !== true) {
+    throw new AuthError("Forbidden", 403);
+  }
+
+  return decoded;
 }

--- a/src/lib/rate-limit.js
+++ b/src/lib/rate-limit.js
@@ -1,0 +1,42 @@
+import { LRUCache } from "lru-cache";
+
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const DEFAULT_MAX = 30;
+const MAX_TRACKED_KEYS = 10000;
+
+const buckets = new LRUCache({
+  max: MAX_TRACKED_KEYS,
+  ttl: DEFAULT_WINDOW_MS * 2,
+});
+
+export function checkRateLimit(key, options = {}) {
+  const limit = options.limit ?? DEFAULT_MAX;
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const now = Date.now();
+  const entry = buckets.get(key);
+
+  if (!entry || now - entry.windowStart >= windowMs) {
+    buckets.set(key, { count: 1, windowStart: now });
+    return { allowed: true, remaining: limit - 1, retryAfterMs: 0 };
+  }
+
+  if (entry.count >= limit) {
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: windowMs - (now - entry.windowStart),
+    };
+  }
+
+  entry.count += 1;
+  buckets.set(key, entry);
+  return { allowed: true, remaining: limit - entry.count, retryAfterMs: 0 };
+}
+
+export function resetRateLimit(key) {
+  buckets.delete(key);
+}
+
+export function clearAllRateLimits() {
+  buckets.clear();
+}


### PR DESCRIPTION
# Closes #308.

## What changed

- `src/lib/auth-server.js`: added `assertAdmin()` and `AuthError`. Verifies the session cookie via Firebase Admin (`verifySessionCookie` then falls back to `verifyIdToken`) and additionally requires `admin === true` on the verified token's custom claims. Throws `AuthError(401)` on bad or missing cookie, `AuthError(403)` on missing admin claim. `getServerSession` is intentionally untouched, that belongs to #251.

- `src/lib/rate-limit.js` (new): small fixed-window rate limiter backed by `lru-cache`, already in `package.json`.

- `src/app/api/research/export/route.js`: gates on `assertAdmin()` first, then per-UID rate limit (30/min, returns 429 with `Retry-After`), then refuses to serve with 503 if `RESEARCH_HASH_SECRET` is unset or the admin DB is uninitialised. Pseudo IDs are now HMAC-SHA-256 keyed by `RESEARCH_HASH_SECRET`. Pagination added via `?limit=` (default 100, max 500) and `?cursor=<lastDocId>`, response shape is `{ data, nextCursor }`. Also fixes a pre-existing timezone bug in `roundTimestamp` (was using local-time `setMinutes`, now uses `setUTCMinutes`).

- `.env.example`: added `RESEARCH_HASH_SECRET` placeholder.

- `src/app/api/research/export/route.test.js` (new): 13 cases, all passing, covering every reject path, the happy path, HMAC determinism, rate-limit-exceeded, the `verifySessionCookie`-then-`verifyIdToken` fallback, cursor pagination, and limit clamping.

## Note on the dependency on #251 / PR #261

The issue body said the fix depended on #261 landing. In practice it does not: `assertAdmin()` calls Firebase Admin's `verifySessionCookie` and `verifyIdToken` directly, which is the canonical primitive and does not rely on the broken `getServerSession`. When #261 lands and migrates `getServerSession` to real session cookies, `assertAdmin()` continues to work without changes. The fallback to `verifyIdToken` exists because the current codebase stores raw ID tokens in the `session` cookie; once #261 switches to real session cookies, the fallback becomes dead code but does not hurt.

## Maintainer action required after merge

1. Add a real value for `RESEARCH_HASH_SECRET` in your production environment. Recommended: at least 32 random bytes, base64-encoded. Rotate on suspected compromise.

2. Grant the admin custom claim to your own Firebase UID (or whichever account should have research-export rights) out of band, for example via a one-off script:

```js
import { getAuth } from "firebase-admin/auth";

await getAuth().setCustomUserClaims("<uid>", { admin: true });
```

Users with `admin: true` will be the only ones able to call `/api/research/export`.

3. The frontend at no point calls this route, so no UI changes were needed.

## Known limitations (intentionally out of scope)

- The rate limit is per-instance only. For multi-instance deployments behind Vercel, each function instance has its own LRU cache. A Redis/Upstash-backed limiter would be needed for true global enforcement. Acceptable for current scale, worth tracking as a follow-up.

- Cursor pagination uses the document ID as cursor. For collections where the natural ordering is timestamp (e.g. `user_activity`), this still works but is not the most efficient ordering. A follow-up can extend to ordered-field cursors.

## Test plan

- [ ] `npm install`
- [ ] `npm run test src/app/api/research/export/route.test.js` (13 cases should all pass)
- [ ] Set `RESEARCH_HASH_SECRET` in `.env.local`, grant the admin claim to one test UID via a one-off `setCustomUserClaims` script, then:
  - [ ] Hit `/api/research/export?type=outcomes` while logged out → expect 401
  - [ ] Hit it while logged in but without the admin claim → expect 403
  - [ ] Hit it while logged in with the admin claim → expect 200 with paginated data
  - [ ] Hit it 31 times in a minute as the same admin → expect the 31st to be 429