### PR TITLE
fix(security): require Bearer auth on /api/content/ingest, add size and rate limits

### DIFF
--- a/src/app/api/content/ingest/route.js
+++ b/src/app/api/content/ingest/route.js
@@ -3,36 +3,88 @@ import { ingestContent } from "@/lib/ingestion-service";
 import { detectFileType } from "@/lib/text-extractor";
 import { createNotification } from "@/lib/create-notification";
 import { getAdminDb } from "@/lib/firebase-admin";
+import { requireBearerAuth, AuthError } from "@/lib/auth-server";
+import { checkRateLimit } from "@/lib/rate-limit";
+
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const PER_USER_LIMIT = 10;
+const PER_IP_LIMIT = 30;
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+
+function getClientIp(request) {
+  const forwarded = request.headers.get("x-forwarded-for");
+  if (forwarded) {
+    const first = forwarded.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const realIp = request.headers.get("x-real-ip");
+  if (realIp) return realIp.trim();
+  return "unknown";
+}
 
 export async function POST(request) {
+  let decoded;
   try {
-    let userId = "anonymous";
-
-    try {
-      const authHeader = request.headers.get("authorization");
-      if (authHeader && authHeader.startsWith("Bearer ")) {
-        const { getAuth } = await import("firebase-admin/auth");
-        const token = authHeader.replace("Bearer ", "");
-        const decoded = await getAuth().verifyIdToken(token);
-        userId = decoded.email || decoded.uid;
-      }
-    } catch (authError) {
-      console.log("[DEBUG] Auth verification failed, using anonymous:", authError.message);
+    decoded = await requireBearerAuth(request);
+  } catch (error) {
+    if (error instanceof AuthError) {
+      return NextResponse.json({ error: error.message }, { status: error.status });
     }
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
 
-    console.log("[DEBUG] Content ingestion userId:", userId);
+  const userId = decoded.email || decoded.uid;
 
+  const userRate = checkRateLimit(`ingest:user:${userId}`, {
+    limit: PER_USER_LIMIT,
+    windowMs: RATE_WINDOW_MS,
+  });
+  if (!userRate.allowed) {
+    return NextResponse.json(
+      { error: "Too many uploads. Please try again later." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil(userRate.retryAfterMs / 1000)) },
+      }
+    );
+  }
+
+  const ipRate = checkRateLimit(`ingest:ip:${getClientIp(request)}`, {
+    limit: PER_IP_LIMIT,
+    windowMs: RATE_WINDOW_MS,
+  });
+  if (!ipRate.allowed) {
+    return NextResponse.json(
+      { error: "Too many uploads from this network. Please try again later." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil(ipRate.retryAfterMs / 1000)) },
+      }
+    );
+  }
+
+  const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+  if (!contentLength) {
+    return NextResponse.json(
+      { error: "Content-Length header is required" },
+      { status: 411 }
+    );
+  }
+  if (contentLength > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: `File too large. Maximum allowed size is ${MAX_UPLOAD_BYTES} bytes.` },
+      { status: 413 }
+    );
+  }
+
+  try {
     const formData = await request.formData();
     const file = formData.get("file");
 
     if (!file) {
-      return NextResponse.json(
-        { error: "No file provided" },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: "No file provided" }, { status: 400 });
     }
 
-    // Validate file type
     const fileType = detectFileType(file.name);
     if (!fileType) {
       return NextResponse.json(
@@ -42,21 +94,29 @@ export async function POST(request) {
         { status: 400 }
       );
     }
+
     const bytes = await file.arrayBuffer();
     const buffer = Buffer.from(bytes);
     const fileSize = buffer.length;
+
+    if (fileSize > MAX_UPLOAD_BYTES) {
+      return NextResponse.json(
+        { error: `File too large. Maximum allowed size is ${MAX_UPLOAD_BYTES} bytes.` },
+        { status: 413 }
+      );
+    }
+
     const result = await ingestContent(buffer, file.name, fileSize, userId);
 
-    if (userId && userId !== "anonymous") {
-      const adminDb = getAdminDb();
-      console.log("[DEBUG] Creating ingestion notification with link:", `/ingested-course/${result.courseId}`);
+    const adminDb = getAdminDb();
+    if (adminDb) {
       createNotification(adminDb, {
         userId,
         title: "Course Created from File!",
         body: `"${result.title}" with ${result.chapterCount} chapters is ready to explore.`,
         type: "progress",
         link: `/ingested-course/${result.courseId}`,
-      }).catch(() => { });
+      }).catch(() => {});
     }
 
     return NextResponse.json({
@@ -72,10 +132,8 @@ export async function POST(request) {
     });
   } catch (error) {
     console.error("Content ingestion error:", error);
-
     const message = error.message || "Failed to ingest content";
     const status = message.includes("Unsupported") || message.includes("too large") ? 400 : 500;
-
     return NextResponse.json({ error: message }, { status });
   }
 }

--- a/src/app/api/content/ingest/route.test.js
+++ b/src/app/api/content/ingest/route.test.js
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("firebase-admin/auth", () => ({
+  getAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase-admin", () => ({
+  getAdminDb: vi.fn(() => null),
+  FieldValue: { increment: (n) => ({ __op: "increment", value: n }) },
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  auth: {},
+}));
+
+vi.mock("@/lib/ingestion-service", () => ({
+  ingestContent: vi.fn(),
+}));
+
+vi.mock("@/lib/text-extractor", () => ({
+  detectFileType: vi.fn(),
+}));
+
+vi.mock("@/lib/create-notification", () => ({
+  createNotification: vi.fn(async () => undefined),
+}));
+
+vi.mock("next/server", () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      json: async () => data,
+      status: init?.status || 200,
+      headers: init?.headers || {},
+    }),
+  },
+}));
+
+import { getAuth } from "firebase-admin/auth";
+import { ingestContent } from "@/lib/ingestion-service";
+import { detectFileType } from "@/lib/text-extractor";
+import { clearAllRateLimits } from "@/lib/rate-limit";
+import { POST } from "./route.js";
+
+function makeReq({
+  authHeader,
+  contentLength,
+  xForwardedFor,
+  file,
+  fileName = "doc.pdf",
+} = {}) {
+  const headers = new Map();
+  if (authHeader !== undefined) headers.set("authorization", authHeader);
+  if (contentLength !== undefined) headers.set("content-length", String(contentLength));
+  if (xForwardedFor !== undefined) headers.set("x-forwarded-for", xForwardedFor);
+
+  return {
+    headers: {
+      get: (name) => headers.get(name.toLowerCase()) ?? null,
+    },
+    formData: async () => ({
+      get: (key) => (key === "file" && file !== undefined ? file : null),
+    }),
+  };
+}
+
+function makeFile(bytes, name = "doc.pdf") {
+  const buf = typeof bytes === "string" ? Buffer.from(bytes) : bytes;
+  return {
+    name,
+    arrayBuffer: async () => buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  clearAllRateLimits();
+  getAuth.mockReturnValue({
+    verifyIdToken: vi.fn(async () => ({ uid: "u1", email: "user@example.com" })),
+  });
+  detectFileType.mockReturnValue("pdf");
+  ingestContent.mockResolvedValue({
+    courseId: "course_123",
+    title: "Test Course",
+    description: "A description",
+    chapterCount: 3,
+    totalWords: 1000,
+    estimatedReadingTime: 5,
+    chapters: [],
+  });
+});
+
+describe("POST /api/content/ingest", () => {
+  it("returns 401 when no Authorization header is present", async () => {
+    const res = await POST(makeReq({ contentLength: 100 }));
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.error).toBe("Unauthorized");
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when Authorization header is missing Bearer prefix", async () => {
+    const res = await POST(makeReq({ authHeader: "Token abc.def.ghi", contentLength: 100 }));
+    expect(res.status).toBe(401);
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when Bearer token is empty", async () => {
+    const res = await POST(makeReq({ authHeader: "Bearer ", contentLength: 100 }));
+    expect(res.status).toBe(401);
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when verifyIdToken throws", async () => {
+    getAuth.mockReturnValue({
+      verifyIdToken: vi.fn(async () => {
+        throw new Error("token expired");
+      }),
+    });
+    const res = await POST(makeReq({ authHeader: "Bearer bad-token", contentLength: 100 }));
+    expect(res.status).toBe(401);
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 411 when Content-Length is missing or zero", async () => {
+    const res = await POST(makeReq({ authHeader: "Bearer ok-token" }));
+    expect(res.status).toBe(411);
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 413 when Content-Length exceeds the maximum upload size", async () => {
+    const res = await POST(
+      makeReq({ authHeader: "Bearer ok-token", contentLength: 100 * 1024 * 1024 })
+    );
+    expect(res.status).toBe(413);
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when no file is provided in the form data", async () => {
+    const res = await POST(
+      makeReq({ authHeader: "Bearer ok-token", contentLength: 500 })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("No file provided");
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the file extension is not supported", async () => {
+    detectFileType.mockReturnValue(null);
+    const res = await POST(
+      makeReq({
+        authHeader: "Bearer ok-token",
+        contentLength: 500,
+        file: makeFile("hello", "doc.exe"),
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 and calls ingestContent on the happy path", async () => {
+    const res = await POST(
+      makeReq({
+        authHeader: "Bearer ok-token",
+        contentLength: 500,
+        file: makeFile("valid-pdf-bytes", "doc.pdf"),
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.courseId).toBe("course_123");
+    expect(ingestContent).toHaveBeenCalledOnce();
+    const [, fileName, , userIdArg] = ingestContent.mock.calls[0];
+    expect(fileName).toBe("doc.pdf");
+    expect(userIdArg).toBe("user@example.com");
+  });
+
+  it("returns 429 after the per-user rate limit is exceeded", async () => {
+    let lastStatus = 0;
+    for (let i = 0; i < 11; i += 1) {
+      const res = await POST(
+        makeReq({
+          authHeader: "Bearer ok-token",
+          contentLength: 500,
+          xForwardedFor: `10.0.0.${i + 1}`,
+          file: makeFile("v", "doc.pdf"),
+        })
+      );
+      lastStatus = res.status;
+    }
+    expect(lastStatus).toBe(429);
+  });
+
+  it("returns 429 after the per-IP rate limit is exceeded", async () => {
+    let lastStatus = 0;
+    for (let i = 0; i < 31; i += 1) {
+      getAuth.mockReturnValue({
+        verifyIdToken: vi.fn(async () => ({ uid: `u${i}`, email: `u${i}@example.com` })),
+      });
+      const res = await POST(
+        makeReq({
+          authHeader: "Bearer ok-token",
+          contentLength: 500,
+          xForwardedFor: "1.2.3.4",
+          file: makeFile("v", "doc.pdf"),
+        })
+      );
+      lastStatus = res.status;
+    }
+    expect(lastStatus).toBe(429);
+  });
+
+  it("does not call ingestContent when rate limited", async () => {
+    for (let i = 0; i < 10; i += 1) {
+      await POST(
+        makeReq({
+          authHeader: "Bearer ok-token",
+          contentLength: 500,
+          xForwardedFor: `9.9.9.${i + 1}`,
+          file: makeFile("v", "doc.pdf"),
+        })
+      );
+    }
+    ingestContent.mockClear();
+    const res = await POST(
+      makeReq({
+        authHeader: "Bearer ok-token",
+        contentLength: 500,
+        xForwardedFor: "9.9.9.99",
+        file: makeFile("v", "doc.pdf"),
+      })
+    );
+    expect(res.status).toBe(429);
+    expect(ingestContent).not.toHaveBeenCalled();
+  });
+
+  it("uses the first IP from x-forwarded-for when it contains a comma-separated list", async () => {
+    const res = await POST(
+      makeReq({
+        authHeader: "Bearer ok-token",
+        contentLength: 500,
+        xForwardedFor: "203.0.113.45, 10.0.0.1, 10.0.0.2",
+        file: makeFile("v", "doc.pdf"),
+      })
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/lib/auth-server.js
+++ b/src/lib/auth-server.js
@@ -1,10 +1,14 @@
 import { cookies } from "next/headers";
 import { auth as firebaseAuth } from "@/lib/firebase";
 
-/**
- * Get the current user from the session cookie
- * This replaces NextAuth's auth() function for API routes
- */
+export class AuthError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.name = "AuthError";
+    this.status = status;
+  }
+}
+
 export async function getServerSession() {
   try {
     const cookieStore = await cookies();
@@ -14,13 +18,8 @@ export async function getServerSession() {
       return null;
     }
 
-    // The session cookie contains the Firebase ID token
-    // For now, we'll decode it client-side style
-    // In production, you should verify it with Firebase Admin SDK
     const idToken = sessionCookie.value;
 
-    // For now, we'll extract user info from the token payload
-    // This is a simplified approach - ideally use Firebase Admin to verify
     try {
       const payload = JSON.parse(atob(idToken.split(".")[1]));
       return {
@@ -37,5 +36,25 @@ export async function getServerSession() {
   } catch (error) {
     console.error("Error getting server session:", error);
     return null;
+  }
+}
+
+export async function requireBearerAuth(request) {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    throw new AuthError("Unauthorized", 401);
+  }
+
+  const token = authHeader.slice("Bearer ".length).trim();
+  if (!token) {
+    throw new AuthError("Unauthorized", 401);
+  }
+
+  try {
+    const { getAuth } = await import("firebase-admin/auth");
+    const decoded = await getAuth().verifyIdToken(token);
+    return decoded;
+  } catch (_) {
+    throw new AuthError("Unauthorized", 401);
   }
 }

--- a/src/lib/rate-limit.js
+++ b/src/lib/rate-limit.js
@@ -1,0 +1,42 @@
+import { LRUCache } from "lru-cache";
+
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const DEFAULT_MAX = 30;
+const MAX_TRACKED_KEYS = 10000;
+
+const buckets = new LRUCache({
+  max: MAX_TRACKED_KEYS,
+  ttl: DEFAULT_WINDOW_MS * 2,
+});
+
+export function checkRateLimit(key, options = {}) {
+  const limit = options.limit ?? DEFAULT_MAX;
+  const windowMs = options.windowMs ?? DEFAULT_WINDOW_MS;
+  const now = Date.now();
+  const entry = buckets.get(key);
+
+  if (!entry || now - entry.windowStart >= windowMs) {
+    buckets.set(key, { count: 1, windowStart: now });
+    return { allowed: true, remaining: limit - 1, retryAfterMs: 0 };
+  }
+
+  if (entry.count >= limit) {
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: windowMs - (now - entry.windowStart),
+    };
+  }
+
+  entry.count += 1;
+  buckets.set(key, entry);
+  return { allowed: true, remaining: limit - entry.count, retryAfterMs: 0 };
+}
+
+export function resetRateLimit(key) {
+  buckets.delete(key);
+}
+
+export function clearAllRateLimits() {
+  buckets.clear();
+}


### PR DESCRIPTION
# Closes #309.

## What changed

- `src/lib/auth-server.js`: added `requireBearerAuth(request)` (symmetric with `assertAdmin()`). Reads the `Authorization: Bearer <token>` header, verifies via Firebase Admin `verifyIdToken`, returns the decoded token. Throws `AuthError(401)` if the header is missing, malformed, empty, or fails verification.

- `src/lib/rate-limit.js` (new): small fixed-window rate limiter backed by `lru-cache`, already in `package.json`. Same module that ships in the PR for #308; identical content so the two PRs will merge cleanly in either order.

- `src/app/api/content/ingest/route.js`: full rewrite of the auth and pre-flight section. The `userId = "anonymous"` default and the swallowing `catch` are both deleted. The new flow is auth check, then per-user rate limit (10/hour), then per-IP rate limit (30/hour), then `Content-Length` check (411 if missing, 413 if over 10 MB), then `formData` parse and existing ingestion pipeline. A defensive secondary size check runs on the actual buffer length after reading, in case a client lies about `Content-Length`.

- `src/app/api/content/ingest/route.test.js` (new): 13 test cases covering every reject path (no header, bad prefix, empty token, verify throws, missing Content-Length, oversized Content-Length, no file, bad extension), the happy path with verified `ingestContent` invocation, both rate-limit thresholds (per-user and per-IP), the assertion that a rate-limited request never reaches `ingestContent`, and the `x-forwarded-for` comma-list parsing.

## Why these limits

- **Auth: 401, no fallback.** Matches the issue body's suggested fix exactly. The frontend at `src/app/content-ingestion/page.jsx` already attaches the Bearer token when the user is logged in (lines 122 to 131), so this does not break the existing UI flow.

- **Max upload: 10 MB.** Matches the suggested value in the issue body. PDF / EPUB study materials rarely exceed this for a single document, and Vercel functions have a memory ceiling that makes larger uploads costly.

- **Per-user: 10 uploads per hour.** Generous for legitimate use, low enough to make abuse uneconomical.

- **Per-IP: 30 uploads per hour.** Catches the "many fake accounts on one IP" pattern without blocking legitimate shared-IP setups (school networks, etc.).

## Frontend impact

None for logged-in users. The frontend already sends the Bearer token for authenticated sessions. The only behaviour change is that anonymous uploads now correctly return 401 instead of silently succeeding under `userId = "anonymous"`.

## Out of scope (per the issue body)

- Migration off `pdf-parse@1.1.1`. Belongs to its own follow-up issue so the auth fix can land quickly.
- Antivirus / content scanning of uploaded files.
- Idempotency on `ingestContent` itself (does not apply here).

## Test plan

- [ ] `npm install`
- [ ] `npm run test src/app/api/content/ingest/route.test.js` (13 cases should all pass)
- [ ] Live test:
  - [ ] `curl -i -X POST <host>/api/content/ingest -F "file=@small.pdf"` with no auth → expect `HTTP 401`
  - [ ] Same with a forged or expired Bearer token → expect `HTTP 401`
  - [ ] Same with a valid token + a 12 MB file → expect `HTTP 413`
  - [ ] Same with a valid token + a 100 KB valid PDF → expect `HTTP 200` with a `courseId`
  - [ ] Loop 11 times with the same valid token → expect the 11th to be `HTTP 429`