### PR TITLE
feat: Continue Learning smart course resume system

### DIFF
--- a/src/app/api/roadmap/[id]/progress/route.js
+++ b/src/app/api/roadmap/[id]/progress/route.js
@@ -1,0 +1,53 @@
+import { adminDb } from "@/lib/firebase-admin";
+import { getServerSession } from "@/lib/auth-server";
+import { NextResponse } from "next/server";
+
+export async function PATCH(req, { params }) {
+  try {
+    const session = await getServerSession();
+    if (!session) {
+      return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const { lastAccessedChapter } = await req.json();
+
+    if (typeof lastAccessedChapter !== "number" || lastAccessedChapter < 0) {
+      return NextResponse.json(
+        { message: "Invalid lastAccessedChapter. Must be a non-negative number." },
+        { status: 400 }
+      );
+    }
+
+    const courseRef = adminDb
+      .collection("users")
+      .doc(session.user.email)
+      .collection("roadmaps")
+      .doc(id);
+
+    const courseSnap = await courseRef.get();
+
+    if (!courseSnap.exists) {
+      return NextResponse.json({ message: "Course not found" }, { status: 404 });
+    }
+
+    await courseRef.update({
+      lastAccessedAt: new Date().toISOString(),
+      lastAccessedChapter: lastAccessedChapter,
+      updatedAt: new Date().toISOString(),
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "Progress updated",
+      lastAccessedAt: new Date().toISOString(),
+      lastAccessedChapter,
+    });
+  } catch (error) {
+    console.error("Error updating course progress:", error);
+    return NextResponse.json(
+      { message: "Failed to update progress", error: error.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/roadmap/all/route.js
+++ b/src/app/api/roadmap/all/route.js
@@ -24,7 +24,9 @@ export async function GET() {
         difficulty: doc.data().difficulty,
         chapters: doc.data().chapters || [],
         chapterCount: doc.data().chapters?.length || 0,
-        archived: doc.data().archived || false, // Include archived status
+        archived: doc.data().archived || false,
+        lastAccessedAt: doc.data().lastAccessedAt || null,
+        lastAccessedChapter: doc.data().lastAccessedChapter ?? null,
       }))
       .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
 

--- a/src/app/roadmap/page.jsx
+++ b/src/app/roadmap/page.jsx
@@ -3,6 +3,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Plus, BookOpen, Sparkles, Search, X, Filter, Trash2, Archive, ArchiveRestore, CheckSquare } from "lucide-react";
 import CourseCard from "@/components/Home/CourseCard";
+import ContinueLearning from "@/components/Home/ContinueLearning";
 import Link from "next/link";
 import { useState, useEffect } from "react";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -126,8 +127,11 @@ export default function page() {
             return matchesSearch && matchesDifficulty;
         })
         .sort((a, b) => {
-            // Sort logic
-            if (sortBy === "newest") {
+            if (sortBy === "recent") {
+                const aTime = a.lastAccessedAt ? new Date(a.lastAccessedAt).getTime() : 0;
+                const bTime = b.lastAccessedAt ? new Date(b.lastAccessedAt).getTime() : 0;
+                return bTime - aTime;
+            } else if (sortBy === "newest") {
                 return new Date(b.createdAt) - new Date(a.createdAt);
             } else if (sortBy === "oldest") {
                 return new Date(a.createdAt) - new Date(b.createdAt);
@@ -244,6 +248,10 @@ export default function page() {
                     <div className="w-full max-w-4xl">
                         <DailyQuests userId={user.email} />
                     </div>
+                )}
+
+                {!loading && !error && completedCourses.length > 0 && (
+                    <ContinueLearning courses={completedCourses} />
                 )}
 
                 {/* Search and Filter Section */}
@@ -389,10 +397,11 @@ export default function page() {
 
                             {/* Sort By */}
                             <Select value={sortBy} onValueChange={setSortBy}>
-                                <SelectTrigger className="w-40 h-9 bg-card/50 backdrop-blur-sm border-border/50">
+                                <SelectTrigger className="w-44 h-9 bg-card/50 backdrop-blur-sm border-border/50">
                                     <SelectValue placeholder="Sort by" />
                                 </SelectTrigger>
                                 <SelectContent>
+                                    <SelectItem value="recent">Recently Accessed</SelectItem>
                                     <SelectItem value="newest">Newest First</SelectItem>
                                     <SelectItem value="oldest">Oldest First</SelectItem>
                                     <SelectItem value="title">Title (A-Z)</SelectItem>

--- a/src/components/Home/ContinueLearning.jsx
+++ b/src/components/Home/ContinueLearning.jsx
@@ -1,0 +1,119 @@
+"use client";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { BookOpen, Play, ArrowRight } from "lucide-react";
+
+const getRelativeTime = (dateString) => {
+  if (!dateString) return null;
+  const now = new Date();
+  const date = new Date(dateString);
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+  return `${Math.floor(diffDays / 30)}mo ago`;
+};
+
+const getProgress = (chapters) => {
+  if (!chapters || chapters.length === 0) return 0;
+  const completed = chapters.filter((ch) => ch.completed).length;
+  return Math.round((completed / chapters.length) * 100);
+};
+
+const getResumeChapter = (course) => {
+  const chapters = course.chapters || [];
+  const lastIdx = course.lastAccessedChapter ?? -1;
+  if (lastIdx >= 0 && lastIdx < chapters.length && !chapters[lastIdx]?.completed) {
+    return lastIdx + 1;
+  }
+  const nextIdx = chapters.findIndex((ch) => !ch.completed);
+  return nextIdx >= 0 ? nextIdx + 1 : chapters.length;
+};
+
+const getResumeHref = (course) => {
+  const chapterNum = getResumeChapter(course);
+  return `/chapter-test/${course.id}/${chapterNum}`;
+};
+
+export default function ContinueLearning({ courses }) {
+  if (!courses || courses.length === 0) return null;
+
+  const inProgress = courses.filter((c) => {
+    const progress = getProgress(c.chapters);
+    return progress > 0 && progress < 100;
+  });
+
+  if (inProgress.length === 0) return null;
+
+  const sorted = [...inProgress].sort((a, b) => {
+    const aTime = a.lastAccessedAt ? new Date(a.lastAccessedAt).getTime() : 0;
+    const bTime = b.lastAccessedAt ? new Date(b.lastAccessedAt).getTime() : 0;
+    return bTime - aTime;
+  });
+
+  const latest = sorted[0];
+  if (!latest.lastAccessedAt) return null;
+
+  const progress = getProgress(latest.chapters);
+  const relativeTime = getRelativeTime(latest.lastAccessedAt);
+  const completedChapters = latest.chapters?.filter((ch) => ch.completed).length || 0;
+  const totalChapters = latest.chapters?.length || 0;
+
+  return (
+    <div className="w-full max-w-4xl">
+      <div className="flex items-center gap-2 mb-3">
+        <Play className="h-4 w-4 text-blue-500" />
+        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+          Continue Learning
+        </h2>
+      </div>
+      <Card className="relative overflow-hidden border-blue-500/20 bg-gradient-to-r from-blue-500/5 via-blue-500/[0.02] to-transparent">
+        <div className="absolute top-0 left-0 w-1 h-full bg-blue-500" />
+        <CardContent className="p-5">
+          <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-1">
+                <BookOpen className="h-4 w-4 text-blue-500 shrink-0" />
+                <span className="text-xs text-muted-foreground">
+                  {completedChapters}/{totalChapters} chapters
+                  {relativeTime && <span className="ml-2">&middot; {relativeTime}</span>}
+                </span>
+              </div>
+              <h3 className="text-lg font-semibold truncate">{latest.courseTitle}</h3>
+              <div className="flex items-center gap-3 mt-2">
+                <div className="flex-1 max-w-xs">
+                  <Progress value={progress} className="h-1.5" indicatorClassName={progress === 100 ? "bg-green-500" : "bg-blue-500"} />
+                </div>
+                <span className="text-xs font-medium text-blue-600 dark:text-blue-400 shrink-0">
+                  {progress}%
+                </span>
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              <Link href={`/roadmap/${latest.id}`}>
+                <Button variant="outline" size="sm" className="gap-1.5">
+                  <BookOpen className="h-3.5 w-3.5" />
+                  View Course
+                </Button>
+              </Link>
+              <Link href={getResumeHref(latest)}>
+                <Button size="sm" className="gap-1.5 bg-blue-600 hover:bg-blue-700 text-white">
+                  <ArrowRight className="h-3.5 w-3.5" />
+                  Continue
+                </Button>
+              </Link>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/Home/CourseCard.jsx
+++ b/src/components/Home/CourseCard.jsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Clock, BookOpen, CheckCircle2 } from "lucide-react";
+import { Clock, BookOpen, CheckCircle2, History } from "lucide-react";
 import { calculateEstimatedTime } from "@/lib/time-utils";
 import { Progress } from "@/components/ui/progress";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -10,8 +10,26 @@ import DeleteRoadmap from "./DeleteRoadmap";
 import ArchiveCourse from "./ArchiveCourse";
 import DuplicateCourse from "./DuplicateCourse";
 
+const getRelativeTime = (dateString) => {
+  if (!dateString) return null;
+  const now = new Date();
+  const date = new Date(dateString);
+  const diffMs = now - date;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return "Just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+  return `${Math.floor(diffDays / 30)}mo ago`;
+};
+
 const CourseCard = ({ course, onDelete, onArchive, isSelectable, isSelected, onSelect }) => {
-  const { id, courseTitle, courseDescription, chapterCount, difficulty, chapters, archived } = course;
+  const { id, courseTitle, courseDescription, chapterCount, difficulty, chapters, archived, lastAccessedAt } = course;
+  const lastAccessedText = getRelativeTime(lastAccessedAt);
 
   // Calculate progress percentage
   const calculateProgress = () => {
@@ -113,6 +131,12 @@ const CourseCard = ({ course, onDelete, onArchive, isSelectable, isSelected, onS
         <CardDescription className="line-clamp-2 text-sm">
           {courseDescription}
         </CardDescription>
+        {lastAccessedText && progress > 0 && progress < 100 && (
+          <div className="flex items-center gap-1 mt-2 text-xs text-muted-foreground">
+            <History className="h-3 w-3" />
+            <span>Last accessed {lastAccessedText}</span>
+          </div>
+        )}
       </CardHeader>
 
       <CardContent className="space-y-3">

--- a/src/components/Home/RoadMap.jsx
+++ b/src/components/Home/RoadMap.jsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useState, useContext } from "react";
-import { CircleCheckIcon, Clock, Copy } from "lucide-react";
+import { CircleCheckIcon, Clock, Copy, ArrowRight } from "lucide-react";
 import xpContext from "@/contexts/xp";
 import { useAuth } from "@/contexts/auth";
 import { calculateEstimatedTime } from "@/lib/time-utils";
@@ -22,6 +22,11 @@ function Roadmap({ roadMap, id }) {
 
   // Calculate estimated time
   const estimatedTime = calculateEstimatedTime(roadMap.chapters.length, roadMap.difficulty);
+
+  // Find first uncompleted chapter for resume
+  const firstUncompletedIndex = roadMap.chapters?.findIndex((ch) => !ch.completed);
+  const resumeChapter =
+    firstUncompletedIndex >= 0 ? firstUncompletedIndex + 1 : roadMap.chapters?.length || 1;
 
   useEffect(() => {
     function updateHeight() {
@@ -90,6 +95,12 @@ function Roadmap({ roadMap, id }) {
 
           {/* Action Buttons */}
           <div className="flex gap-2 shrink-0">
+            <Link href={`/chapter-test/${id}/${resumeChapter}`}>
+              <Button size="sm" className="gap-1.5 bg-blue-600 hover:bg-blue-700 text-white">
+                <ArrowRight className="h-4 w-4" />
+                Resume
+              </Button>
+            </Link>
             <ExportCourse
               courseId={id}
               courseTitle={roadMap.courseTitle}

--- a/src/components/chapter_content/page.jsx
+++ b/src/components/chapter_content/page.jsx
@@ -312,6 +312,18 @@ const Page = ({ chapter, roadmapId }) => {
         hideLoader();
     }, []);
 
+    // Track progress when chapter content loads
+    useEffect(() => {
+        if (chapterData && roadmapId) {
+            const chapterIndex = Number(chapter) - 1;
+            fetch(`/api/roadmap/${roadmapId}/progress`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ lastAccessedChapter: chapterIndex }),
+            }).catch(() => {});
+        }
+    }, [chapterData, roadmapId, chapter]);
+
     if (isLoading) {
         return (
             <ChapterLoading


### PR DESCRIPTION
 **"Continue Learning"** smart course resume system that lets users instantly pick up where they left off. Previously, the platform had no tracking of which chapter was last accessed on AI-generated courses — users had to manually find and navigate to their last chapter.

#331

## Changes

| File | Action | Description |
|---|---|---|
| `src/app/api/roadmap/[id]/progress/route.js` | Created | `PATCH` endpoint to save `lastAccessedAt` + `lastAccessedChapter` on roadmap documents |
| `src/app/api/roadmap/all/route.js` | Modified | Now returns `lastAccessedAt` and `lastAccessedChapter` fields in course list |
| `src/components/Home/ContinueLearning.jsx` | Created | Dashboard component showing the most recently accessed in-progress course with a "Continue" button |
| `src/app/roadmap/page.jsx` | Modified | Added Continue Learning section above course grid; added "Recently Accessed" sort option |
| `src/components/Home/CourseCard.jsx` | Modified | Shows "Last accessed X ago" badge for in-progress courses |
| `src/components/Home/RoadMap.jsx` | Modified | Added "Resume" button that navigates to the first uncompleted chapter |
| `src/components/chapter_content/page.jsx` | Modified | Auto-tracks progress by calling the progress API when chapter content loads |

## How It Works

1. User opens a chapter → `PATCH /api/roadmap/[id]/progress` saves `lastAccessedAt` + `lastAccessedChapter`
2. On `/roadmap`, the `ContinueLearning` component picks the most recently accessed in-progress course
3. Course cards display "Last accessed X ago" for recently viewed courses
4. Course detail page has a "Resume" button jumping directly to the first uncompleted chapter
5. Users can sort courses by "Recently Accessed"

## Verification

- Build compiles successfully (`✓ Compiled successfully`)
- All **20 relevant tests pass** (6 pre-existing failures in `certificates/generate` are unrelated Firebase credential issues)
