### PR TITLE
fix(api): implement fault-tolerant Razorpay order creation pipeline

### DIFF
--- a/src/app/api/premium/create-order/route.js
+++ b/src/app/api/premium/create-order/route.js
@@ -21,19 +21,28 @@ const COUPONS = {
 
 export async function POST(req) {
   try {
-    // Check if Razorpay keys are configured
+    // Check if Razorpay keys are configured — this is a gateway config issue, not a server bug
     if (!process.env.RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
       console.error("Razorpay keys not configured");
       return NextResponse.json(
         { error: "Payment gateway not configured", details: "Missing Razorpay API keys" },
-        { status: 500 }
+        { status: 502 }
       );
     }
 
-    const razorpay = new Razorpay({
-      key_id: process.env.RAZORPAY_KEY_ID,
-      key_secret: process.env.RAZORPAY_KEY_SECRET,
-    });
+    let razorpay;
+    try {
+      razorpay = new Razorpay({
+        key_id: process.env.RAZORPAY_KEY_ID,
+        key_secret: process.env.RAZORPAY_KEY_SECRET,
+      });
+    } catch (initError) {
+      console.error("Razorpay initialization failed:", initError.message);
+      return NextResponse.json(
+        { error: "Payment gateway initialization failed", details: initError.message },
+        { status: 502 }
+      );
+    }
 
     const session = await getServerSession();
 
@@ -83,24 +92,54 @@ export async function POST(req) {
       couponValid = true;
     }
 
-    const finalAmount = Math.max(baseAmount - discountApplied, 100); // Minimum ₹1
+    const finalAmount = Math.max(baseAmount - discountApplied, 100); // Minimum ₹1 (100 paise)
+    const currency = "INR";
+
+    // Validate payload before dispatching to Razorpay SDK
+    if (!Number.isInteger(finalAmount) || finalAmount < 100) {
+      return NextResponse.json(
+        { error: "Invalid order amount", details: "Amount must be at least ₹1 (100 paise)" },
+        { status: 400 }
+      );
+    }
+
+    if (currency !== "INR") {
+      return NextResponse.json(
+        { error: "Invalid currency", details: "Only INR is supported" },
+        { status: 400 }
+      );
+    }
+
     const planLabel = planType === "education" ? "edu" : "prem";
 
     // Receipt must be max 40 characters
     const receipt = `${planLabel}_${Date.now()}`;
-    const order = await razorpay.orders.create({
-      amount: finalAmount,
-      currency: "INR",
-      receipt: receipt,
-      notes: {
-        email: session.user.email,
-        type: planType === "education" ? "education_subscription" : "premium_subscription",
-        planType: planType,
-        couponCode: couponCode || "none",
-        originalAmount: baseAmount,
-        discountApplied: discountApplied,
-      },
-    });
+
+    let order;
+    try {
+      order = await razorpay.orders.create({
+        amount: finalAmount,
+        currency,
+        receipt,
+        notes: {
+          email: session.user.email,
+          type: planType === "education" ? "education_subscription" : "premium_subscription",
+          planType: planType,
+          couponCode: couponCode || "none",
+          originalAmount: baseAmount,
+          discountApplied: discountApplied,
+        },
+      });
+    } catch (razorpayError) {
+      console.error("Razorpay order creation failed:", razorpayError.message, razorpayError);
+      return NextResponse.json(
+        {
+          error: "Payment gateway error",
+          details: razorpayError.error?.description || razorpayError.message || "Razorpay rejected the order request",
+        },
+        { status: 502 }
+      );
+    }
 
     return NextResponse.json({
       orderId: order.id,
@@ -113,7 +152,7 @@ export async function POST(req) {
       planType: planType,
     });
   } catch (error) {
-    console.error("Error creating Razorpay order:", error.message, error);
+    console.error("Unexpected error in create-order:", error.message, error);
     return NextResponse.json(
       { error: "Failed to create order", details: error.message || "Unknown error" },
       { status: 500 }

--- a/src/app/api/premium/verify-payment/route.js
+++ b/src/app/api/premium/verify-payment/route.js
@@ -5,6 +5,14 @@ import crypto from "crypto";
 
 export async function POST(req) {
   try {
+    if (!process.env.RAZORPAY_KEY_SECRET) {
+      console.error("RAZORPAY_KEY_SECRET not configured");
+      return NextResponse.json(
+        { error: "Payment gateway not configured", details: "Missing Razorpay secret key" },
+        { status: 502 }
+      );
+    }
+
     const session = await getServerSession();
 
     if (!session?.user) {
@@ -12,6 +20,13 @@ export async function POST(req) {
     }
 
     const { razorpay_order_id, razorpay_payment_id, razorpay_signature } = await req.json();
+
+    if (!razorpay_order_id || !razorpay_payment_id || !razorpay_signature) {
+      return NextResponse.json(
+        { error: "Invalid payload", details: "razorpay_order_id, razorpay_payment_id, and razorpay_signature are required" },
+        { status: 400 }
+      );
+    }
 
     // Verify signature
     const body = razorpay_order_id + "|" + razorpay_payment_id;


### PR DESCRIPTION



## Which issue does this PR close?
Closes #362

## Rationale for this change
The production environment was throwing unhandled `500 Internal Server Error`s when the Razorpay gateway failed to initialize or rejected malformed payloads. This PR establishes a strict error boundary at the API layer to prevent cascading server crashes during the checkout lifecycle.

## What changes are included in this PR?
- Implemented `try/catch` wrappers around the Razorpay instance initialization and `orders.create` methods.
- Added strict payload validation in `/create-order` (enforcing `currency === "INR"` and `amount >= 100` paise), returning deterministic `400 Bad Request` responses.
- Added pre-flight environment variable checks in both `/create-order` and `/verify-payment`, returning `502 Bad Gateway` if Razorpay keys are missing.
- Added payload validation in `/verify-payment` to ensure required Razorpay IDs and signatures are present before processing.

## Are these changes tested?
Yes. Verified the deterministic error responses (400 and 502) locally by simulating missing API keys and malformed checkout payloads.

## Are there any user-facing changes?
No UI component changes, but the frontend will now receive actionable JSON error responses instead of triggering a hard server crash when payment initialization fails.

<img width="1919" height="1021" alt="Screenshot 2026-05-23 225849" src="https://github.com/user-attachments/assets/8ced39de-c901-42ce-819e-31e9131608f9" />
<img width="1919" height="965" alt="Screenshot 2026-05-23 230038" src="https://github.com/user-attachments/assets/178011a7-3433-4d40-801f-acd7cc643a61" />