### PR TITLE
fix(firebase-admin): use FIREBASE_ADMIN_ env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,11 @@ NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=your_storage_bucket
 NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your_sender_id
 NEXT_PUBLIC_FIREBASE_APP_ID=your_app_id
 
+# Firebase Admin (Server-side)
+FIREBASE_ADMIN_PROJECT_ID=your_project_id
+FIREBASE_ADMIN_CLIENT_EMAIL=your_service_account_email
+FIREBASE_ADMIN_PRIVATE_KEY="your_private_key"
+
 # Google Gemini API
 NEXT_PUBLIC_GEMINI_API_KEY=your_gemini_api_key
 

--- a/src/lib/firebase-admin.js
+++ b/src/lib/firebase-admin.js
@@ -7,9 +7,9 @@ let isInitialized = false;
 function initializeFirebaseAdmin() {
   if (isInitialized) return adminDb;
   isInitialized = true;
-  const projectId = process.env.FIREBASE_PROJECT_ID;
-  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
-  const privateKey = process.env.FIREBASE_PRIVATE_KEY;
+  const projectId = process.env.FIREBASE_ADMIN_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_ADMIN_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_ADMIN_PRIVATE_KEY;
 
   if (!projectId || !clientEmail || !privateKey) {
     console.warn("Firebase Admin SDK: Missing credentials. Server-side database operations will be limited.");


### PR DESCRIPTION
## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #344.

## Rationale for this change

The platform’s setup documentation (`README.md`, `.env.example`, `.env.local`) documents Firebase Admin credentials using the `FIREBASE_ADMIN_` prefix, but the server‑side initialization code in `src/lib/firebase-admin.js` was still reading the older `FIREBASE_` variables.  

This mismatch prevented `initializeFirebaseAdmin()` from locating valid credentials, causing `adminDb` to be `null` and resulting in 500 errors for server‑side features such as public course listings, share‑dialog toggles, and analytics. The fix aligns the code with the documented environment variables, restoring proper admin initialization.

## What changes are included in this PR?

- **`src/lib/firebase-admin.js`** – Updated to read `FIREBASE_ADMIN_PROJECT_ID`, `FIREBASE_ADMIN_CLIENT_EMAIL`, and `FIREBASE_ADMIN_PRIVATE_KEY` instead of the outdated variables.
- **`CONTRIBUTING.md`** – Added the Firebase Admin environment variables (`FIREBASE_ADMIN_*`) to the `.env.local` example section, keeping the documentation consistent with the codebase.
- Minor documentation tweaks to clarify the separation between client‑side (`NEXT_PUBLIC_FIREBASE_*`) and server‑side (`FIREBASE_ADMIN_*`) credentials.

## Are these changes tested?

Yes.

- Ran the application locally (`npm run dev`) with a `.env.local` file containing the new `FIREBASE_ADMIN_*` variables.
- Verified that server‑side Firebase operations (e.g., toggling a course’s visibility to “Public” and fetching the public courses list) now work without errors.
- Confirmed no new console warnings or runtime exceptions appear.

## Are there any user‑facing changes?

- The environment variable names required for server‑side Firebase Admin setup have been documented more clearly. Users must now set `FIREBASE_ADMIN_PROJECT_ID`, `FIREBASE_ADMIN_CLIENT_EMAIL`, and `FIREBASE_ADMIN_PRIVATE_KEY` in their `.env.local` file.
- No UI or functional changes are exposed directly to end‑users; the fix only resolves backend initialization errors.
