### PR TITLE
fix: correct formatTimestamp to accept seconds not milliseconds (#335)

### DIFF
--- a/src/app/api/youtube/transcript/route.js
+++ b/src/app/api/youtube/transcript/route.js
@@ -90,17 +90,17 @@ export async function POST(request) {
   }
 }
 
-function formatTimestamp(ms) {
-  if (!ms && ms !== 0) return "0:00";
-  const totalSeconds = Math.floor(ms / 1000);
+export function formatTimestamp(seconds) {
+  if (!seconds && seconds !== 0) return "0:00";
+  const totalSeconds = Math.floor(seconds);
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
+  const secs = totalSeconds % 60;
 
   if (hours > 0) {
-    return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
   }
-  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+  return `${minutes}:${secs.toString().padStart(2, '0')}`;
 }
 
 function generateFallbackTranscript(videoId) {

--- a/src/app/api/youtube/transcript/route.test.js
+++ b/src/app/api/youtube/transcript/route.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { POST, formatTimestamp } from './route';
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      _data: data,
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+vi.mock('youtube-transcript', () => ({
+  YoutubeTranscript: {
+    fetchTranscript: vi.fn(),
+  },
+}));
+
+function makeRequest(body) {
+  return { json: async () => body };
+}
+
+// --- formatTimestamp unit tests ---
+
+describe('formatTimestamp', () => {
+  it('returns "0:00" for 0 seconds', () => {
+    expect(formatTimestamp(0)).toBe('0:00');
+  });
+
+  it('returns "0:00" for null/undefined input', () => {
+    expect(formatTimestamp(null)).toBe('0:00');
+    expect(formatTimestamp(undefined)).toBe('0:00');
+  });
+
+  it('formats sub-minute offsets correctly', () => {
+    expect(formatTimestamp(5)).toBe('0:05');
+    expect(formatTimestamp(59)).toBe('0:59');
+  });
+
+  it('formats minute-range offsets correctly', () => {
+    expect(formatTimestamp(60)).toBe('1:00');
+    expect(formatTimestamp(65)).toBe('1:05');
+    expect(formatTimestamp(600)).toBe('10:00');
+    expect(formatTimestamp(3599)).toBe('59:59');
+  });
+
+  it('formats hour-range offsets correctly', () => {
+    expect(formatTimestamp(3600)).toBe('1:00:00');
+    expect(formatTimestamp(3661)).toBe('1:01:01');
+    expect(formatTimestamp(7384)).toBe('2:03:04');
+  });
+
+  it('floors fractional seconds from the library', () => {
+    expect(formatTimestamp(65.789)).toBe('1:05');
+    expect(formatTimestamp(3661.999)).toBe('1:01:01');
+  });
+
+  it('does not divide by 1000 (regression: offset was treated as milliseconds)', () => {
+    // If the old ms/1000 bug were present, formatTimestamp(65) would return "0:00"
+    expect(formatTimestamp(65)).not.toBe('0:00');
+  });
+});
+
+// --- POST route integration tests ---
+
+describe('POST /api/youtube/transcript', () => {
+  it('returns 400 when videoId is missing', async () => {
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toBe('Video ID is required');
+  });
+
+  it('uses second-based offsets from the library correctly', async () => {
+    const { YoutubeTranscript } = await import('youtube-transcript');
+    YoutubeTranscript.fetchTranscript.mockResolvedValue([
+      { text: 'Hello', offset: 65, duration: 2, lang: 'en' },
+      { text: 'World', offset: 130, duration: 2, lang: 'en' },
+    ]);
+
+    const res = await POST(makeRequest({ videoId: 'dQw4w9WgXcQ' }));
+    const data = await res.json();
+
+    expect(data.success).toBe(true);
+    expect(data.detailedTranscript[0].timestamp).toBe('1:05');
+    expect(data.detailedTranscript[1].timestamp).toBe('2:10');
+    expect(data.timestampedTranscript).toContain('[1:05] Hello');
+    expect(data.timestampedTranscript).toContain('[2:10] World');
+  });
+});


### PR DESCRIPTION
## Problem

`YoutubeTranscript.fetchTranscript` returns each item's `offset` in seconds, parsed directly from YouTube's XML `start` attribute (e.g., `65.234` for 1 minute 5 seconds). The `formatTimestamp` function in `src/app/api/youtube/transcript/route.js` assumed millisecond input and divided by 1000, so a 65-second offset was computed as `Math.floor(65 / 1000) = 0`, producing `"0:00"` for every timestamp in that range.

Closes #335.

## Changes

**`src/app/api/youtube/transcript/route.js`**
- Rename the `formatTimestamp` parameter from `ms` to `seconds`.
- Replace `Math.floor(ms / 1000)` with `Math.floor(seconds)` so the raw library offset is used directly.
- Rename the inner `seconds` local variable to `secs` to remove the shadowing conflict introduced by the parameter rename.
- Export `formatTimestamp` to allow direct unit testing.

**`src/app/api/youtube/transcript/route.test.js`** (new)
- Unit tests for `formatTimestamp`: zero, sub-minute, minute-range, hour-range, fractional-second truncation, and a regression guard that explicitly verifies `formatTimestamp(65)` returns `"1:05"` and not `"0:00"`.
- Integration tests for the `POST` handler: missing `videoId` validation, and an end-to-end check that confirms `detailedTranscript` and `timestampedTranscript` contain correctly formatted timestamps when the library returns second-based offsets.

## Test results

```
src/app/api/youtube/transcript/route.test.js (9 tests) 4ms
Test Files  1 passed (1)
Tests       9 passed (9)
```