### PR TITLE
fix: prevent repeated quiz and exercise submissions from farming XP (#337)

### DIFF
--- a/src/app/api/youtube/exercises/route.js
+++ b/src/app/api/youtube/exercises/route.js
@@ -148,16 +148,25 @@ export async function PUT(request) {
 
     if (adminDb) {
       try {
-        await adminDb
+        const courseDocRef = adminDb
           .collection("users")
           .doc(session.user.email)
           .collection("youtube-courses")
-          .doc(courseId)
-          .update({
-            [`exerciseProgress.chapter${chapterNumber}.${exerciseId}`]: submissionData,
-            updatedAt: new Date().toISOString()
-          });
-        await awardExerciseXP(session.user.email, 5, chapterNumber, exerciseId);
+          .doc(courseId);
+
+        const courseDoc = await courseDocRef.get();
+        const courseData = courseDoc.exists ? courseDoc.data() : {};
+        const alreadyCompleted =
+          courseData.exerciseProgress?.[`chapter${chapterNumber}`]?.[exerciseId]?.status === "completed";
+
+        await courseDocRef.update({
+          [`exerciseProgress.chapter${chapterNumber}.${exerciseId}`]: submissionData,
+          updatedAt: new Date().toISOString()
+        });
+
+        if (!alreadyCompleted) {
+          await awardExerciseXP(session.user.email, 5, chapterNumber, exerciseId);
+        }
       } catch (dbError) {
         console.warn("Could not save exercise to Firebase:", dbError.message);
       }

--- a/src/app/api/youtube/exercises/route.test.js
+++ b/src/app/api/youtube/exercises/route.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      _data: data,
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const mockGetAdminDb = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/firebase-admin', () => ({
+  getAdminDb: mockGetAdminDb,
+}));
+
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth-server', () => ({
+  getServerSession: mockGetServerSession,
+}));
+
+vi.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: class {
+    getGenerativeModel() {
+      return { generateContent: vi.fn() };
+    }
+  },
+}));
+
+import { PUT } from './route';
+
+function makeDocMock(exists, data) {
+  return { exists, data: () => data };
+}
+
+function makeAdminDb({ courseData, runTransaction }) {
+  const courseRef = {
+    get: vi.fn().mockResolvedValue(makeDocMock(courseData !== null, courseData ?? {})),
+    update: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    collection: vi.fn().mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        collection: vi.fn().mockReturnValue({
+          doc: vi.fn().mockReturnValue(courseRef),
+        }),
+      }),
+    }),
+    runTransaction: runTransaction ?? vi.fn().mockImplementation(async (fn) => fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: vi.fn() })),
+    _courseRef: courseRef,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetServerSession.mockResolvedValue({ user: { email: 'test@example.com' } });
+});
+
+describe('PUT /api/youtube/exercises - XP farming regression', () => {
+  it('awards XP on first exercise submission', async () => {
+    const courseData = { exerciseProgress: {} };
+
+    const txSet = vi.fn();
+    const db = makeAdminDb({
+      courseData,
+      runTransaction: vi.fn().mockImplementation(async (fn) => {
+        await fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: txSet });
+      }),
+    });
+    mockGetAdminDb.mockReturnValue(db);
+
+    const res = await PUT({
+      json: async () => ({ courseId: 'c1', chapterNumber: 1, exerciseId: 'ex1', solution: 'done' }),
+    });
+    const data = await res.json();
+
+    expect(data.success).toBe(true);
+    expect(txSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not award XP when the exercise was already completed (farming guard)', async () => {
+    const courseData = {
+      exerciseProgress: {
+        chapter1: {
+          ex1: { status: 'completed', submittedAt: '2026-05-23T00:00:00.000Z' },
+        },
+      },
+    };
+
+    const txSet = vi.fn();
+    const db = makeAdminDb({
+      courseData,
+      runTransaction: vi.fn().mockImplementation(async (fn) => {
+        await fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: txSet });
+      }),
+    });
+    mockGetAdminDb.mockReturnValue(db);
+
+    const res = await PUT({
+      json: async () => ({ courseId: 'c1', chapterNumber: 1, exerciseId: 'ex1', solution: 'resubmit' }),
+    });
+    const data = await res.json();
+
+    expect(data.success).toBe(true);
+    expect(txSet).not.toHaveBeenCalled();
+  });
+
+  it('awards XP for a different exercise in the same chapter', async () => {
+    const courseData = {
+      exerciseProgress: {
+        chapter1: {
+          ex1: { status: 'completed', submittedAt: '2026-05-23T00:00:00.000Z' },
+        },
+      },
+    };
+
+    const txSet = vi.fn();
+    const db = makeAdminDb({
+      courseData,
+      runTransaction: vi.fn().mockImplementation(async (fn) => {
+        await fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: txSet });
+      }),
+    });
+    mockGetAdminDb.mockReturnValue(db);
+
+    const res = await PUT({
+      json: async () => ({ courseId: 'c1', chapterNumber: 1, exerciseId: 'ex2', solution: 'new' }),
+    });
+    const data = await res.json();
+
+    expect(data.success).toBe(true);
+    expect(txSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await PUT({ json: async () => ({}) });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/app/api/youtube/quiz/route.js
+++ b/src/app/api/youtube/quiz/route.js
@@ -178,7 +178,8 @@ export async function PUT(request) {
           },
           updatedAt: new Date().toISOString()
         });
-      if (passed) {
+      const alreadyPassed = courseData.quizScores?.[`chapter${chapterNumber}`]?.passed === true;
+      if (passed && !alreadyPassed) {
         const xpEarned = Math.round(score / 10);
         await awardQuizXP(session.user.email, xpEarned, chapterNumber);
       }

--- a/src/app/api/youtube/quiz/route.test.js
+++ b/src/app/api/youtube/quiz/route.test.js
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      _data: data,
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const mockGetAdminDb = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/firebase-admin', () => ({
+  getAdminDb: mockGetAdminDb,
+}));
+
+const mockGetServerSession = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/auth-server', () => ({
+  getServerSession: mockGetServerSession,
+}));
+
+vi.mock('@google/generative-ai', () => ({
+  GoogleGenerativeAI: class {
+    getGenerativeModel() {
+      return { generateContent: vi.fn() };
+    }
+  },
+}));
+
+import { PUT } from './route';
+
+function makeDocMock(exists, data) {
+  return { exists, data: () => data };
+}
+
+function makeAdminDb({ courseData, runTransaction }) {
+  const courseRef = {
+    get: vi.fn().mockResolvedValue(makeDocMock(true, courseData)),
+    update: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    collection: vi.fn().mockReturnValue({
+      doc: vi.fn().mockReturnValue({
+        collection: vi.fn().mockReturnValue({
+          doc: vi.fn().mockReturnValue(courseRef),
+        }),
+      }),
+    }),
+    runTransaction: runTransaction ?? vi.fn().mockImplementation(async (fn) => fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: vi.fn() })),
+    _courseRef: courseRef,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetServerSession.mockResolvedValue({ user: { email: 'test@example.com' } });
+});
+
+describe('PUT /api/youtube/quiz - XP farming regression', () => {
+  it('awards XP on first passing submission', async () => {
+    const courseData = {
+      chapters: [{
+        quiz: {
+          questions: [{ id: 'q1', correctAnswer: 0, explanation: '' }],
+          passingScore: 70,
+        },
+      }],
+      quizScores: {},
+    };
+
+    const txSet = vi.fn();
+    const db = makeAdminDb({
+      courseData,
+      runTransaction: vi.fn().mockImplementation(async (fn) => {
+        await fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: txSet });
+      }),
+    });
+    mockGetAdminDb.mockReturnValue(db);
+
+    const res = await PUT({ json: async () => ({ courseId: 'c1', chapterNumber: 1, answers: [0] }) });
+    const data = await res.json();
+
+    expect(data.passed).toBe(true);
+    expect(txSet).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not award XP when the chapter quiz was already passed (farming guard)', async () => {
+    const courseData = {
+      chapters: [{
+        quiz: {
+          questions: [{ id: 'q1', correctAnswer: 0, explanation: '' }],
+          passingScore: 70,
+        },
+      }],
+      quizScores: {
+        chapter1: { score: 100, passed: true, completedAt: '2026-05-23T00:00:00.000Z', results: [] },
+      },
+    };
+
+    const txSet = vi.fn();
+    const db = makeAdminDb({
+      courseData,
+      runTransaction: vi.fn().mockImplementation(async (fn) => {
+        await fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: txSet });
+      }),
+    });
+    mockGetAdminDb.mockReturnValue(db);
+
+    const res = await PUT({ json: async () => ({ courseId: 'c1', chapterNumber: 1, answers: [0] }) });
+    const data = await res.json();
+
+    expect(data.passed).toBe(true);
+    expect(txSet).not.toHaveBeenCalled();
+  });
+
+  it('does not award XP when the submission fails (score below passing threshold)', async () => {
+    const courseData = {
+      chapters: [{
+        quiz: {
+          questions: [
+            { id: 'q1', correctAnswer: 0, explanation: '' },
+            { id: 'q2', correctAnswer: 1, explanation: '' },
+          ],
+          passingScore: 70,
+        },
+      }],
+      quizScores: {},
+    };
+
+    const txSet = vi.fn();
+    const db = makeAdminDb({
+      courseData,
+      runTransaction: vi.fn().mockImplementation(async (fn) => {
+        await fn({ get: vi.fn().mockResolvedValue(makeDocMock(false, null)), set: txSet });
+      }),
+    });
+    mockGetAdminDb.mockReturnValue(db);
+
+    // Both answers wrong
+    const res = await PUT({ json: async () => ({ courseId: 'c1', chapterNumber: 1, answers: [1, 0] }) });
+    const data = await res.json();
+
+    expect(data.passed).toBe(false);
+    expect(txSet).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await PUT({ json: async () => ({}) });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 503 when Firebase is not configured', async () => {
+    mockGetAdminDb.mockReturnValue(null);
+    const res = await PUT({ json: async () => ({ courseId: 'c1', chapterNumber: 1, answers: [] }) });
+    expect(res.status).toBe(503);
+  });
+});


### PR DESCRIPTION
## Problem

Both the quiz `PUT` handler (`src/app/api/youtube/quiz/route.js`) and the exercise `PUT` handler (`src/app/api/youtube/exercises/route.js`) awarded XP on every passing submission with no guard against re-submission. A user could submit the same quiz or exercise repeatedly to accumulate unlimited XP.

Closes #337.

## Root Cause

**Quiz handler:** Awards XP inside `if (passed)` but never checks whether the chapter was already passed in the stored `quizScores`.

**Exercise handler:** Awards 5 XP on every submission but never checks whether `exerciseProgress[chapter][exerciseId]` already has `status: "completed"`.

## Changes

**`src/app/api/youtube/quiz/route.js`**

The course document is already fetched before grading begins, so `courseData` already carries the previous `quizScores`. Read `courseData.quizScores?.[chapter]?.passed` before awarding XP and skip the award if the chapter was already passed:

```js
const alreadyPassed = courseData.quizScores?.[`chapter${chapterNumber}`]?.passed === true;
if (passed && !alreadyPassed) {
  const xpEarned = Math.round(score / 10);
  await awardQuizXP(session.user.email, xpEarned, chapterNumber);
}
```

**`src/app/api/youtube/exercises/route.js`**

The `PUT` handler previously wrote the submission and immediately called `awardExerciseXP` without reading the course document first. Add a read to check existing progress, then guard the XP award:

```js
const courseDoc = await courseDocRef.get();
const courseData = courseDoc.exists ? courseDoc.data() : {};
const alreadyCompleted =
  courseData.exerciseProgress?.[`chapter${chapterNumber}`]?.[exerciseId]?.status === "completed";

await courseDocRef.update({ ... });

if (!alreadyCompleted) {
  await awardExerciseXP(session.user.email, 5, chapterNumber, exerciseId);
}
```

## Tests

**`quiz/route.test.js`** (5 cases):
- First passing submission awards XP.
- Resubmission of an already-passed chapter does NOT award XP (farming guard).
- Failed submission (score below passing threshold) does not award XP.
- Unauthenticated request returns 401.
- Unconfigured Firebase returns 503.

**`exercises/route.test.js`** (4 cases):
- First submission awards XP.
- Resubmission of an already-completed exercise does NOT award XP (farming guard).
- Submitting a different exercise in the same chapter still awards XP.
- Unauthenticated request returns 401.

```
src/app/api/youtube/exercises/route.test.js  (4 tests) 5ms
src/app/api/youtube/quiz/route.test.js       (5 tests) 5ms
Test Files  2 passed (2)
Tests       9 passed (9)
```