### PR TITLE
fix: navbar links on feedback page now navigate correctly

### DIFF
--- a/src/components/Navbar/DesktopNav.jsx
+++ b/src/components/Navbar/DesktopNav.jsx
@@ -40,26 +40,17 @@ const DesktopNav = ({
           ))}
         </div>
       ) : (
-        // Landing page nav - pill style buttons with text
+        // Landing page nav - pill style buttons with text (uses href links)
         <div className="flex items-center gap-0.5 px-2 py-1.5 rounded-full border border-border/50 bg-card/80 backdrop-blur-md shadow-sm">
           {landingNavItems.map((item) => (
             <Button
-              key={item.id || item.href}
+              key={item.href}
               variant="ghost"
               size="sm"
-              asChild={!!item.href}
-              onClick={() => {
-                if (item.id) {
-                  document.getElementById(item.id)?.scrollIntoView({ behavior: "smooth" });
-                }
-              }}
+              asChild
               className="text-sm font-light text-foreground hover:bg-muted hover:text-foreground rounded-full h-8 px-4 transition-colors"
             >
-              {item.href ? (
-                <Link href={item.href}>{item.label}</Link>
-              ) : (
-                <span className="cursor-pointer">{item.label}</span>
-              )}
+              <Link href={item.href}>{item.label}</Link>
             </Button>
           ))}
         </div>

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -149,12 +149,12 @@ const Navbar = () => {
     { href: "/contact", label: "Contact", icon: MessageSquare, description: "Get in touch" },
   ];
 
-  // Landing page navigation
+  // ✅ UPDATED: landing page navigation items now use href with hash
   const landingNavItems = [
-    { id: "features", label: "Features" },
-    { id: "how-it-works", label: "How It Works" },
-    { id: "faq", label: "FAQ" },
-    { id: "contact", label: "Contact" },
+    { label: "Features", href: "/#features" },
+    { label: "How It Works", href: "/#how-it-works" },
+    { label: "FAQ", href: "/#faq" },
+    { label: "Contact", href: "/#contact" },
   ];
 
   return (
@@ -235,7 +235,6 @@ const Navbar = () => {
                 </Tooltip>
               </>
             )}
-
 
             {user && <NotificationBell />}
 


### PR DESCRIPTION
## 🔧 Fix Navbar Links on Feedback Page – Issue #371

### What this PR does
- Updated `landingNavItems` in `Navbar.jsx` to use `href` with hash (`/#features`, `/#how-it-works`, `/#faq`, `/#contact`)
- Simplified `DesktopNav.jsx` landing section to use `<Link href={item.href}>` instead of manual `scrollIntoView`
- Now clicking navbar links on the `/feedback` page correctly navigates to the home page and scrolls to the respective section

### Before / After
| Before | After |
|--------|-------|
| Clicking "Features" on feedback page does nothing | Clicking "Features" navigates to `/` and scrolls to Features section |
| Links relied on `document.getElementById` (not present on feedback page) | Links use native browser navigation with hash |
| No feedback for other links | All four links (Features, How It Works, FAQ, Contact) work correctly |

### Testing done
- Manually tested on `/feedback` page – all navbar links now navigate and scroll as expected
- Logged‑out user experience unchanged on landing page
- Logged‑in user navigation (icons) unaffected by changes

### Closes #371 