### PR TITLE
fix: make motivational quote changes accessible

### DIFF
--- a/src/components/dashboard/MotivationalQuote.jsx
+++ b/src/components/dashboard/MotivationalQuote.jsx
@@ -123,27 +123,35 @@ export default function MotivationalQuote({ variant = "default" }) {
             <Quote className="h-6 w-6 text-white" />
           </div>
 
-          <div className="space-y-4 max-w-2xl">
-            <p className="text-xl md:text-2xl font-light tracking-tight leading-relaxed italic text-foreground/90">
-              "{quote.text}"
-            </p>
-            <div className="flex flex-col items-center gap-4 pt-2">
-              <div className="h-px w-12 bg-linear-to-r from-transparent via-border to-transparent" />
-              <p className="text-sm font-medium tracking-widest uppercase text-muted-foreground/80">
-                {quote.author}
-              </p>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={changeQuote}
-                disabled={isChanging}
-                className="mt-2 rounded-full h-10 w-10 p-0 text-muted-foreground hover:text-blue-500 hover:bg-blue-500/5 transition-all"
-                aria-label="Refresh quote"
-              >
-                <RefreshCw className={`h-4 w-4 ${isChanging ? "animate-spin" : ""}`} />
-              </Button>
-            </div>
-          </div>
+          <div
+  className="space-y-4 max-w-2xl"
+  aria-live="polite"
+>
+  <p className="text-xl md:text-2xl font-light tracking-tight leading-relaxed italic text-foreground/90">
+    "{quote.text}"
+  </p>
+
+  <div className="flex flex-col items-center gap-4 pt-2">
+    <div className="h-px w-12 bg-linear-to-r from-transparent via-border to-transparent" />
+
+    <p className="text-sm font-medium tracking-widest uppercase text-muted-foreground/80">
+      {quote.author}
+    </p>
+
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={changeQuote}
+      disabled={isChanging}
+      className="mt-2 rounded-full h-10 w-10 p-0 text-muted-foreground hover:text-blue-500 hover:bg-blue-500/5 transition-all"
+      aria-label="Refresh quote"
+    >
+      <RefreshCw
+        className={`h-4 w-4 ${isChanging ? "animate-spin" : ""}`}
+      />
+    </Button>
+  </div>
+</div>
         </div>
       </div>
     </Card>


### PR DESCRIPTION
## Which issue does this PR close?

* Closes #397

## Rationale for this change

When a user refreshes the motivational quote, the displayed quote changes visually, but screen readers are not notified of the updated content. This affects accessibility for visually impaired users who rely on assistive technologies.

## What changes are included in this PR?

* Added `aria-live="polite"` to the motivational quote container.
* Ensured that updated quotes are announced by screen readers when the quote is refreshed.
* Improved accessibility without affecting existing functionality or UI.

## Are these changes tested?

Yes.

* Verified that the application runs successfully using `npm run dev`.
* Confirmed that the change does not introduce any build or runtime errors.
* Verified that the quote refresh functionality continues to work as expected.

## Are there any user-facing changes?

Yes.

Users who rely on screen readers will now be notified when the motivational quote changes, resulting in a more accessible and inclusive user experience.
