### PR TITLE
fix(navbar): make navigation responsive across breakpoints

### DIFF
--- a/src/components/Navbar/DesktopNav.jsx
+++ b/src/components/Navbar/DesktopNav.jsx
@@ -15,10 +15,10 @@ const DesktopNav = ({
   isActiveLink,
 }) => {
   return (
-    <nav className="hidden md:flex items-center absolute left-1/2 -translate-x-1/2">
+    <nav className="hidden lg:flex flex-1 min-w-0 items-center justify-center">
       {user ? (
         // Logged in users - show ALL 11 nav items with icons only
-        <div className="flex items-center gap-0.5 px-2 py-1.5 rounded-full border border-border/50 bg-card/80 backdrop-blur-md shadow-sm">
+        <div className="flex max-w-full items-center gap-0.5 px-2 py-1.5 rounded-full border border-border/50 bg-card/80 backdrop-blur-md shadow-sm overflow-hidden">
           {[...createMenuItems, ...learnMenuItems, ...moreMenuItems].map((item) => (
             <Tooltip key={item.href}>
               <TooltipTrigger asChild>
@@ -41,7 +41,7 @@ const DesktopNav = ({
         </div>
       ) : (
         // Landing page nav - pill style buttons with text
-        <div className="flex items-center gap-0.5 px-2 py-1.5 rounded-full border border-border/50 bg-card/80 backdrop-blur-md shadow-sm">
+        <div className="flex max-w-full items-center gap-0.5 px-2 py-1.5 rounded-full border border-border/50 bg-card/80 backdrop-blur-md shadow-sm overflow-hidden">
           {landingNavItems.map((item) => (
             <Button
               key={item.id || item.href}

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -160,7 +160,7 @@ const Navbar = () => {
   return (
     <>
       <header className="h-16 w-full border-b fixed top-0 left-0 bg-background/80 backdrop-blur-xl z-[100] border-border">
-        <div className="h-full max-w-7xl mx-auto px-3 sm:px-4 md:px-6 flex items-center justify-between">
+        <div className="h-full max-w-7xl mx-auto px-3 sm:px-4 md:px-6 flex items-center gap-2 lg:gap-4 min-w-0">
           {/* Logo - Left */}
           <Link
             href={user ? `/roadmap` : "/"}
@@ -181,7 +181,7 @@ const Navbar = () => {
           />
 
           {/* Right Section */}
-          <div className="flex items-center gap-0.5 sm:gap-2 shrink-0">
+          <div className="ml-auto flex items-center gap-0.5 sm:gap-2 shrink-0 min-w-0">
             {user && (
               <>
                 {/* Premium Badge */}
@@ -287,7 +287,7 @@ const Navbar = () => {
             <Button
               variant="ghost"
               size="icon"
-              className="md:hidden h-8 w-8 sm:h-9 sm:w-9 rounded-full hover:bg-muted text-foreground"
+              className="lg:hidden h-8 w-8 sm:h-9 sm:w-9 rounded-full hover:bg-muted text-foreground"
               aria-label={mobileMenuOpen ? "Close menu" : "Open menu"}
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
             >


### PR DESCRIPTION
Updated the navbar to behave properly on mobile, tablet, and desktop screens. The desktop nav now stays in normal flex flow and only appears on large screens, while the mobile hamburger menu appears earlier to prevent overflow and layout crowding. Kept the existing theme and added smoother responsive behavior without changing the overall visual style.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
