### PR TITLE
fix: recommendations refresh endpoint always returns 400, silent error swallowing

### DIFF
--- a/src/app/api/recommendations/route.js
+++ b/src/app/api/recommendations/route.js
@@ -192,12 +192,19 @@ export async function POST(request) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
-        const { courseId, feedbackType } = await request.json(); // feedbackType: "not_interested" or "already_know"
+        const { courseId, feedbackType } = await request.json(); // feedbackType: "not_interested", "already_know", or "refresh"
+        const userEmail = session.user.email;
+
+        // Handle refresh action: invalidate cache and return
+        if (feedbackType === "refresh") {
+            await adminDb.collection("users").doc(userEmail).collection("recommendations").doc("state").delete();
+            return NextResponse.json({ success: true });
+        }
+
         if (!courseId) {
             return NextResponse.json({ error: "Course ID required" }, { status: 400 });
         }
 
-        const userEmail = session.user.email;
         await adminDb.collection("users").doc(userEmail).collection("recommendationFeedback").doc(courseId).set({
             type: feedbackType,
             timestamp: Date.now()

--- a/src/components/RecommendedCourses.jsx
+++ b/src/components/RecommendedCourses.jsx
@@ -66,6 +66,9 @@ const RecommendedCourses = ({ query = "" }) => {
                 }
                 toast.success(feedbackType === "not_interested" ? "We'll show you fewer courses like this." : "Got it! We'll update your recommendations.");
                 setRecommendations(prev => prev.filter(r => r.id !== courseId));
+            } else {
+                const err = await response.json().catch(() => ({}));
+                toast.error(err.error || "Failed to update recommendations");
             }
         } catch (error) {
             toast.error("Failed to update recommendations");


### PR DESCRIPTION
Fixes #441

## Bugs Fixed

### 1. Refresh button always failed (400)
The frontend sent `courseId: null` + `feedbackType: "refresh"` but the backend required a non-null `courseId`, returning 400 for every refresh attempt.

**Fix**: Added `refresh` handling in `POST /api/recommendations` that invalidates the cache and returns success without requiring `courseId`.

### 2. Silent error swallowing on refresh failure
The frontend `handleFeedback` had no `else` clause on `response.ok`, so HTTP errors were silently ignored. Users would click refresh, see no feedback, and the recommendations would not update.

**Fix**: Added `else` block that parses the error response and shows a toast with the actual error message.

## Testing
- Refresh button now invalidates cache and regenerates recommendations
- HTTP errors show a toast with the error message instead of failing silently