### PR TITLE
Fix: Correct invalid Lucide icon name 'Message' to 'Mail' in navigation table

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ InnoVision is a cutting-edge AI-powered learning platform that dynamically gener
 | Trophy | Features | Platform features |
 | Zap | Achievements | Badges & rewards |
 | BarChart | Demo | See how it works |
-| Message | Contact | Get in touch |
+<!-- Fix: Corrected invalid Lucide icon name 'Message' to 'Mail' for Contact navigation item -->
+| Mail | Contact | Get in touch |
 
 ---
 


### PR DESCRIPTION
## Which issue does this PR close?
- Closes #

## Rationale for this change
The Navigation Icons table in README.md had an invalid 
Lucide icon name 'Message' for the Contact navigation item.
'Message' is not a valid icon in the Lucide React library.
The correct icon name for contact/email is 'Mail'.

## What changes are included in this PR?
- Updated Navigation Icons table in README.md
- Changed invalid Lucide icon name 'Message' to 'Mail' 
  for the Contact navigation item

## Are these changes tested?
This is a documentation-only change. No code logic is 
affected. Manually verified by checking the Lucide icons 
library at lucide.dev/icons that 'Mail' is a valid icon 
name and 'Message' is not.

## Are there any user-facing changes?
No user-facing changes — this is a README documentation 
fix only.