### PR TITLE
security: enforce strict URL protocol whitelist validation in Markdown component to prevent XSS

### DIFF
--- a/src/components/MarkDown.jsx
+++ b/src/components/MarkDown.jsx
@@ -180,6 +180,27 @@ const MarkDown = ({ content }) => {
             </li>
           );
         },
+        a({ href, children }) {
+          const isSafe = href && (
+            href.startsWith("http://") || 
+            href.startsWith("https://") || 
+            href.startsWith("mailto:") || 
+            href.startsWith("tel:") || 
+            href.startsWith("/") || 
+            href.startsWith("#")
+          );
+          const safeHref = isSafe ? href : "#";
+          return (
+            <a 
+              href={safeHref} 
+              target={safeHref.startsWith("http") ? "_blank" : "_self"} 
+              rel="noopener noreferrer" 
+              className="text-primary hover:underline font-medium"
+            >
+              {children}
+            </a>
+          );
+        },
         code({ node, inline, className, children, ...props }) {
           const match = /language-(\w+)/.exec(className || "");
           const codeString = String(children).trim();


### PR DESCRIPTION
Closes #474 

# Problem
Rendered markdown content could contain malicious link protocols (e.g. `javascript:`, `data:`), making the application vulnerable to XSS injection.

# Current Behavior
Links are rendered directly.

# Why This Improvement Is Needed
Filtering protocols prevents script injections from AI generation inputs.

# Proposed Solution
Parse and sanitize Markdown link elements using protocol check rules.

# Expected Outcome
Secure link parsing without XSS vectors.
