### PR TITLE
feat: add collaborative study group rooms with username-based invitat…

### DIFF
--- a/src/app/api/rooms/create/route.js
+++ b/src/app/api/rooms/create/route.js
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { adminDb } from "@/lib/firebase-admin";
+
+async function getUser(req) {
+  const authHeader = req.headers.get("authorization") || "";
+  const token = authHeader.replace("Bearer ", "");
+  if (!token) return null;
+  try {
+    const { getAuth } = await import("firebase-admin/auth");
+    const decoded = await getAuth().verifyIdToken(token);
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(req) {
+  const user = await getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { name, topic } = await req.json();
+  if (!name?.trim()) return NextResponse.json({ error: "Room name required" }, { status: 400 });
+
+  const room = {
+    name: name.trim(),
+    topic: topic?.trim() || "",
+    creatorUid: user.uid,
+    members: [user.uid],
+    createdAt: new Date(),
+    isPublic: false,
+  };
+
+  const ref = await adminDb.collection("rooms").add(room);
+  return NextResponse.json({ roomId: ref.id, ...room });
+}

--- a/src/app/api/rooms/invite/route.js
+++ b/src/app/api/rooms/invite/route.js
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { adminDb } from "@/lib/firebase-admin";
+
+async function getUser(req) {
+  const authHeader = req.headers.get("authorization") || "";
+  const token = authHeader.replace("Bearer ", "");
+  if (!token) return null;
+  try {
+    const { getAuth } = await import("firebase-admin/auth");
+    const decoded = await getAuth().verifyIdToken(token);
+    return decoded;
+  } catch {
+    return null;
+  }
+}
+export async function POST(req) {
+  const user = await getUser(req);
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { roomId, username } = await req.json();
+
+  // Look up invited user by username field
+  const userSnap = await adminDb
+    .collection("users")
+    .where("username", "==", username)
+    .limit(1)
+    .get();
+
+  if (userSnap.empty) {
+    return NextResponse.json({ error: "User not found. Make sure you typed the username correctly." }, { status: 404 });
+  }
+
+  const invitedUserDoc = userSnap.docs[0];
+  const invitedUser = invitedUserDoc.data();
+
+  const roomSnap = await adminDb.collection("rooms").doc(roomId).get();
+  if (!roomSnap.exists) {
+    return NextResponse.json({ error: "Room not found" }, { status: 404 });
+  }
+
+  const room = roomSnap.data();
+
+  // Check if already a member
+  if (room.members.includes(invitedUserDoc.id)) {
+    return NextResponse.json({ error: "User is already in this room" }, { status: 400 });
+  }
+
+  await adminDb.collection("invitations").add({
+    roomId,
+    roomName: room.name,
+    fromUid: user.uid,
+    fromName: user.name || user.email,
+    toEmail: invitedUserDoc.id,      
+    toUsername: username,
+    status: "pending",
+    createdAt: new Date(),
+  });
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/rooms/join/route.js
+++ b/src/app/api/rooms/join/route.js
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { adminDb } from "@/lib/firebase-admin";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { FieldValue } from "firebase-admin/firestore";
+
+export async function POST(req) {
+  const session = await getServerSession(authOptions);
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { inviteId } = await req.json();
+
+  const inviteSnap = await adminDb.collection("invitations").doc(inviteId).get();
+  if (!inviteSnap.exists) return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+
+  const invite = inviteSnap.data();
+
+if (invite.toEmail !== user.email){
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  // Add user to room members array
+  await adminDb.collection("rooms").doc(invite.roomId).update({
+    members: FieldValue.arrayUnion(session.user.id),
+  });
+
+  // Mark invite as accepted
+  await adminDb.collection("invitations").doc(inviteId).update({
+    status: "accepted",
+  });
+
+  return NextResponse.json({ roomId: invite.roomId });
+}

--- a/src/app/study-rooms/page.jsx
+++ b/src/app/study-rooms/page.jsx
@@ -1,0 +1,284 @@
+"use client";
+import { useState, useEffect } from "react";
+import { useAuth } from "@/contexts/auth";
+import { db } from "@/lib/firebase";
+import { collection, addDoc, serverTimestamp, doc, getDoc, updateDoc, arrayUnion } from "firebase/firestore";
+import { Users, Plus, X, Check } from "lucide-react";
+import RoomList from "@/components/study-rooms/RoomList";
+import ChatWindow from "@/components/study-rooms/ChatWindow";
+import InviteModal from "@/components/study-rooms/InviteModal";
+import { useSearchParams, useRouter } from "next/navigation";
+
+export default function StudyRoomsPage() {
+  const { user } = useAuth();
+  const [selectedRoom, setSelectedRoom] = useState(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  const [roomName, setRoomName] = useState("");
+  const [roomTopic, setRoomTopic] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  // Invite acceptance state
+  const [pendingInvite, setPendingInvite] = useState(null); // { id, roomId, roomName, fromName }
+  const [inviteAction, setInviteAction] = useState(null);   // "accepting" | "declining" | "done"
+
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // On load, check if URL has ?invite=INVITE_ID
+  useEffect(() => {
+    const inviteId = searchParams.get("invite");
+    if (!inviteId || !user) return;
+
+    const fetchInvite = async () => {
+      try {
+        const inviteSnap = await getDoc(doc(db, "invitations", inviteId));
+        if (!inviteSnap.exists()) return;
+        const data = inviteSnap.data();
+
+        // Only show if this invite is for the current user and still pending
+        if (data.toEmail !== user.email || data.status !== "pending") return;
+
+        setPendingInvite({ id: inviteId, ...data });
+      } catch (err) {
+        console.error("Error fetching invite:", err);
+      }
+    };
+
+    fetchInvite();
+  }, [searchParams, user]);
+
+  const acceptInvite = async () => {
+    if (!pendingInvite || !user) return;
+    setInviteAction("accepting");
+    try {
+      // 1. Add user to room members
+      await updateDoc(doc(db, "rooms", pendingInvite.roomId), {
+        members: arrayUnion(user.uid),
+      });
+
+      // 2. Mark invite as accepted
+      await updateDoc(doc(db, "invitations", pendingInvite.id), {
+        status: "accepted",
+      });
+
+      // 3. Load the room and select it so user lands in the chat
+      const roomSnap = await getDoc(doc(db, "rooms", pendingInvite.roomId));
+      if (roomSnap.exists()) {
+        setSelectedRoom({ id: roomSnap.id, ...roomSnap.data() });
+      }
+
+      setInviteAction("done");
+      setPendingInvite(null);
+
+      // Clean URL
+      router.replace("/study-rooms");
+    } catch (err) {
+      console.error("Error accepting invite:", err);
+      setInviteAction(null);
+    }
+  };
+
+  const declineInvite = async () => {
+    if (!pendingInvite) return;
+    setInviteAction("declining");
+    try {
+      await updateDoc(doc(db, "invitations", pendingInvite.id), {
+        status: "declined",
+      });
+      setPendingInvite(null);
+      setInviteAction(null);
+      router.replace("/study-rooms");
+    } catch (err) {
+      console.error("Error declining invite:", err);
+      setInviteAction(null);
+    }
+  };
+
+  const createRoom = async () => {
+    if (!roomName.trim() || !user) return;
+    setCreating(true);
+    try {
+      const docRef = await addDoc(collection(db, "rooms"), {
+        name: roomName.trim(),
+        topic: roomTopic.trim(),
+        creatorUid: user.uid,
+        members: [user.uid],
+        createdAt: serverTimestamp(),
+        isPublic: false,
+      });
+      setSelectedRoom({ id: docRef.id, name: roomName.trim(), topic: roomTopic.trim(), members: [user.uid] });
+      setRoomName("");
+      setRoomTopic("");
+      setShowCreateModal(false);
+    } catch (err) {
+      console.error("Error creating room:", err);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center h-[calc(100vh-4rem)]">
+        <p className="text-muted-foreground">Please log in to access study rooms.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-4rem)] mt-16">
+
+      {/* INVITE BANNER — shown when URL has ?invite=... */}
+      {pendingInvite && (
+        <div className="w-full bg-primary/10 border-b border-primary/20 px-4 py-3 flex items-center justify-between gap-4 shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="h-8 w-8 rounded-full bg-primary/20 flex items-center justify-center shrink-0">
+              <Users className="h-4 w-4 text-primary" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                <span className="text-primary">{pendingInvite.fromName}</span> invited you to join{" "}
+                <span className="font-semibold">"{pendingInvite.roomName}"</span>
+              </p>
+              <p className="text-xs text-muted-foreground">Study room invitation</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <button
+              onClick={declineInvite}
+              disabled={!!inviteAction}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs hover:bg-muted transition-colors disabled:opacity-50"
+            >
+              <X className="h-3.5 w-3.5" />
+              Decline
+            </button>
+            <button
+              onClick={acceptInvite}
+              disabled={!!inviteAction}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-primary text-primary-foreground text-xs hover:opacity-90 transition-opacity disabled:opacity-50"
+            >
+              <Check className="h-3.5 w-3.5" />
+              {inviteAction === "accepting" ? "Joining..." : "Accept & Join"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* MAIN CONTENT */}
+      <div className="flex flex-1 overflow-hidden">
+
+        {/* LEFT SIDEBAR */}
+        <div className="w-72 border-r border-border flex flex-col shrink-0">
+          <div className="p-4 border-b border-border flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Users className="h-4 w-4 text-muted-foreground" />
+              <span className="font-medium text-sm">Study Rooms</span>
+            </div>
+            <button
+              onClick={() => setShowCreateModal(true)}
+              className="h-7 w-7 rounded-full hover:bg-muted flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors"
+              title="Create room"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto p-2">
+            <RoomList onSelectRoom={setSelectedRoom} selectedRoom={selectedRoom} />
+          </div>
+        </div>
+
+        {/* RIGHT — chat area */}
+        <div className="flex-1 flex flex-col overflow-hidden">
+          {selectedRoom ? (
+            <>
+              <div className="h-14 border-b border-border px-4 flex items-center justify-between shrink-0">
+                <div>
+                  <p className="font-medium text-sm">{selectedRoom.name}</p>
+                  {selectedRoom.topic && (
+                    <p className="text-xs text-muted-foreground">{selectedRoom.topic}</p>
+                  )}
+                </div>
+                <button
+                  onClick={() => setShowInviteModal(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-border text-xs hover:bg-muted transition-colors"
+                >
+                  <Users className="h-3.5 w-3.5" />
+                  Invite
+                </button>
+              </div>
+              <div className="flex-1 overflow-hidden">
+                <ChatWindow room={selectedRoom} />
+              </div>
+            </>
+          ) : (
+            <div className="flex-1 flex flex-col items-center justify-center gap-4 text-center p-8">
+              <div className="h-16 w-16 rounded-full bg-muted flex items-center justify-center">
+                <Users className="h-7 w-7 text-muted-foreground" />
+              </div>
+              <div>
+                <p className="font-medium text-foreground mb-1">No room selected</p>
+                <p className="text-sm text-muted-foreground">
+                  Pick a room from the sidebar or create a new one
+                </p>
+              </div>
+              <button
+                onClick={() => setShowCreateModal(true)}
+                className="flex items-center gap-2 px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm hover:opacity-90 transition-opacity"
+              >
+                <Plus className="h-4 w-4" />
+                Create a room
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* CREATE ROOM MODAL */}
+      {showCreateModal && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-background rounded-xl p-6 w-full max-w-sm shadow-xl border border-border">
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-semibold">Create a study room</h2>
+              <button onClick={() => setShowCreateModal(false)} className="text-muted-foreground hover:text-foreground">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <input
+              value={roomName}
+              onChange={(e) => setRoomName(e.target.value)}
+              placeholder="Room name (e.g. React Study Group)"
+              className="w-full px-3 py-2 rounded-lg border text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-primary bg-background"
+            />
+            <input
+              value={roomTopic}
+              onChange={(e) => setRoomTopic(e.target.value)}
+              placeholder="Topic (optional)"
+              className="w-full px-3 py-2 rounded-lg border text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-primary bg-background"
+            />
+            <div className="flex gap-2">
+              <button
+                onClick={() => setShowCreateModal(false)}
+                className="flex-1 py-2 rounded-lg border text-sm hover:bg-muted transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={createRoom}
+                disabled={!roomName.trim() || creating}
+                className="flex-1 py-2 bg-primary text-primary-foreground rounded-lg text-sm hover:opacity-90 disabled:opacity-50 transition-opacity"
+              >
+                {creating ? "Creating..." : "Create"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* INVITE MODAL */}
+      {showInviteModal && selectedRoom && (
+        <InviteModal room={selectedRoom} onClose={() => setShowInviteModal(false)} />
+      )}
+    </div>
+  );
+}

--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -19,6 +19,7 @@ import {
   Menu,
   X,
   Zap,
+  Users,
 } from "lucide-react";
 import { Sun, Moon } from "lucide-react";
 import Image from "next/image";
@@ -147,6 +148,7 @@ const Navbar = () => {
     { href: "/gamification", label: "Achievements", icon: Zap, description: "Badges & rewards" },
     { href: "/demo", label: "Demo", icon: BarChart3, description: "See how it works" },
     { href: "/contact", label: "Contact", icon: MessageSquare, description: "Get in touch" },
+    { href: "/study-rooms", label: "Study Rooms", icon: Users, description: "Collaborative study" },
   ];
 
   // Landing page navigation

--- a/src/components/study-rooms/ChatWindow.jsx
+++ b/src/components/study-rooms/ChatWindow.jsx
@@ -1,0 +1,104 @@
+"use client";
+import { useState, useEffect, useRef } from "react";
+import { db } from "@/lib/firebase";
+import {
+  collection, query, orderBy, onSnapshot,
+  addDoc, serverTimestamp,
+} from "firebase/firestore";
+import { useAuth } from "@/contexts/auth";
+
+export default function ChatWindow({ room }) {
+  const { user } = useAuth();
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState("");
+  const bottomRef = useRef(null);
+  const hasAwardedXpRef = useRef(false); // ← was missing, caused crash
+
+  useEffect(() => {
+    if (!room) return;
+    const q = query(
+      collection(db, "rooms", room.id, "messages"),
+      orderBy("timestamp", "asc")
+    );
+    const unsub = onSnapshot(q, (snap) => {
+      setMessages(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    });
+    return unsub;
+  }, [room]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  const sendMessage = async () => {
+    if (!text.trim()) return;
+    await addDoc(collection(db, "rooms", room.id, "messages"), {
+      uid: user.uid,
+      displayName: user.displayName,
+      photoURL: user.photoURL,
+      text: text.trim(),
+      timestamp: serverTimestamp(),
+    });
+    setText("");
+
+    // Award XP only once per room visit
+    if (!hasAwardedXpRef.current) {
+      hasAwardedXpRef.current = true;
+      await fetch("/api/gamification/stats", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "help_student" }),
+      });
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            className={`flex gap-2 ${msg.uid === user.uid ? "flex-row-reverse" : ""}`}
+          >
+            <img
+              src={msg.photoURL}
+              alt={msg.displayName}
+              className="w-8 h-8 rounded-full flex-shrink-0"
+            />
+            <div
+              className={`max-w-xs px-3 py-2 rounded-2xl text-sm ${
+                msg.uid === user.uid
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted"
+              }`}
+            >
+              {msg.uid !== user.uid && (
+                <p className="text-xs font-medium mb-1 opacity-70">
+                  {msg.displayName}
+                </p>
+              )}
+              {msg.text}
+            </div>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="p-3 border-t flex gap-2">
+        <input
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => e.key === "Enter" && sendMessage()}
+          placeholder="Type a message..."
+          className="flex-1 px-3 py-2 rounded-lg border text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+        <button
+          onClick={sendMessage}
+          className="px-4 py-2 bg-primary text-primary-foreground rounded-lg text-sm hover:opacity-90"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/study-rooms/InviteModal.jsx
+++ b/src/components/study-rooms/InviteModal.jsx
@@ -1,0 +1,85 @@
+"use client";
+import { useState } from "react";
+import { useAuth } from "@/contexts/auth";
+import { auth } from "@/lib/firebase";
+
+export default function InviteModal({ room, onClose }) {
+  const [username, setUsername] = useState("");
+  const [status, setStatus] = useState(null); // null | "loading" | "success" | "error"
+  const [errorMsg, setErrorMsg] = useState("");
+  const { user } = useAuth();
+
+  const sendInvite = async () => {
+  if (!username.trim()) return;
+  setStatus("loading");
+  try {
+    const token = await auth.currentUser.getIdToken();  // ← get token
+    const res = await fetch("/api/rooms/invite", {
+      method: "POST",
+      headers: { 
+        "Content-Type": "application/json",
+        "Authorization": `Bearer ${token}`,             // ← send it
+      },
+      body: JSON.stringify({ roomId: room.id, username: username.trim() }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error);
+    setStatus("success");
+  } catch (err) {
+    setStatus("error");
+    setErrorMsg(err.message);
+  }
+};
+
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-background rounded-xl p-6 w-full max-w-sm shadow-xl">
+        <h2 className="text-lg font-semibold mb-1">Invite to {room.name}</h2>
+       <p className="text-sm text-muted-foreground mb-3">
+  Enter the username of the person you want to invite.
+</p>
+<p className="text-xs text-muted-foreground mb-4 bg-muted px-3 py-2 rounded-lg">
+  💡 Username is the part before <span className="font-medium">@gmail.com</span> in their email.
+  For example, if their email is <span className="font-medium">john.doe@gmail.com</span>, their username is <span className="font-medium">john.doe</span>
+</p>
+
+        {status === "success" ? (
+          <div className="text-center py-4">
+            <p className="text-green-600 font-medium">Invite sent!</p>
+            <button onClick={onClose} className="mt-3 text-sm text-muted-foreground underline">
+              Close
+            </button>
+          </div>
+        ) : (
+          <>
+            <input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="e.g. john_doe"
+              className="w-full px-3 py-2 rounded-lg border text-sm mb-3 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            {status === "error" && (
+              <p className="text-sm text-red-500 mb-3">{errorMsg}</p>
+            )}
+            <div className="flex gap-2">
+              <button
+                onClick={onClose}
+                className="flex-1 py-2 rounded-lg border text-sm hover:bg-muted"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={sendInvite}
+                disabled={status === "loading"}
+                className="flex-1 py-2 bg-primary text-primary-foreground rounded-lg text-sm hover:opacity-90 disabled:opacity-50"
+              >
+                {status === "loading" ? "Sending..." : "Send invite"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/study-rooms/RoomList.jsx
+++ b/src/components/study-rooms/RoomList.jsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState, useEffect } from "react";
+import { db } from "@/lib/firebase";
+import { collection, query, where, onSnapshot } from "firebase/firestore";
+import { useAuth } from "@/contexts/auth";
+
+export default function RoomList({ onSelectRoom, selectedRoom }) {
+  const { user } = useAuth();
+  const [rooms, setRooms] = useState([]);
+
+  useEffect(() => {
+    if (!user?.uid) return;
+
+    const q = query(
+      collection(db, "rooms"),
+      where("members", "array-contains", user.uid)
+    );
+
+    const unsub = onSnapshot(q, (snap) => {
+      setRooms(snap.docs.map((d) => ({ id: d.id, ...d.data() })));
+    });
+
+    return unsub;
+  }, [user?.uid]);
+
+  if (rooms.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground px-2 py-4 text-center">
+        No rooms yet. Create one!
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {rooms.map((room) => (
+        <button
+          key={room.id}
+          onClick={() => onSelectRoom(room)}
+          className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors ${
+            selectedRoom?.id === room.id
+              ? "bg-primary/10 text-primary"
+              : "hover:bg-muted text-foreground"
+          }`}
+        >
+          <p className="text-sm font-medium truncate">{room.name}</p>
+          {room.topic && (
+            <p className="text-xs text-muted-foreground truncate">{room.topic}</p>
+          )}
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {room.members?.length || 1} member{room.members?.length !== 1 ? "s" : ""}
+          </p>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/contexts/auth.js
+++ b/src/contexts/auth.js
@@ -112,6 +112,7 @@ export function AuthProvider({ children }) {
           email: user.email,
           image: user.photoURL,
           provider: providerName,
+          username: user.email.split("@")[0],
           xp: 0,
           roadmapLevel: {
             fast: 0,

--- a/src/contexts/notifications.js
+++ b/src/contexts/notifications.js
@@ -2,6 +2,8 @@
 
 import { createContext, useContext, useState, useEffect, useCallback } from "react";
 import { useAuth } from "@/contexts/auth";
+import { db } from "@/lib/firebase";
+import { collection, query, where, onSnapshot } from "firebase/firestore";
 
 const NotificationContext = createContext();
 
@@ -22,8 +24,15 @@ export function NotificationProvider({ children }) {
             const res = await fetch("/api/notifications?limit=20");
             if (res.ok) {
                 const data = await res.json();
-                setNotifications(data.notifications || []);
-                setUnreadCount(data.unreadCount || 0);
+                setNotifications(prev => {
+                    const inviteNotifs = prev.filter(n => n.id.startsWith("invite_"));
+                    return [...(data.notifications || []), ...inviteNotifs];
+                });
+                setUnreadCount(prev => {
+                    const inviteUnread = notifications
+                        .filter(n => n.id.startsWith("invite_") && !n.read).length;
+                    return (data.unreadCount || 0) + inviteUnread;
+                });
             }
         } catch (error) {
             console.error("Error fetching notifications:", error);
@@ -32,7 +41,6 @@ export function NotificationProvider({ children }) {
         }
     }, [user]);
 
-    // Fetch on mount and when user changes, then poll every 60 seconds
     useEffect(() => {
         fetchNotifications();
         if (!user) return;
@@ -40,7 +48,49 @@ export function NotificationProvider({ children }) {
         return () => clearInterval(interval);
     }, [user, fetchNotifications]);
 
+    useEffect(() => {
+        if (!user?.uid) return;
+
+        const inviteQuery = query(
+            collection(db, "invitations"),
+            where("toEmail", "==", user.email),
+            where("status", "==", "pending")
+        );
+
+        const unsubscribe = onSnapshot(inviteQuery, (snapshot) => {
+            const inviteNotifs = snapshot.docs.map((d) => ({
+                id: "invite_" + d.id,         
+                type: "social",                
+                title: `Study room invite from ${d.data().fromName}`,
+                body: `You're invited to join "${d.data().roomName}"`,
+                link: `/study-rooms?invite=${d.id}`,
+                read: false,
+                createdAt: d.data().createdAt?.toDate?.()?.toISOString() || new Date().toISOString(),
+            }));
+            setNotifications(prev => [
+                ...prev.filter(n => !n.id.startsWith("invite_")),
+                ...inviteNotifs,
+            ]);
+            setUnreadCount(prev => {
+                const apiUnread = notifications.filter(
+                    n => !n.id.startsWith("invite_") && !n.read
+                ).length;
+                return apiUnread + inviteNotifs.length;
+            });
+        });
+
+        return () => unsubscribe(); // cleanup when user logs out or component unmounts
+    }, [user?.uid]);
+
     const markAsRead = async (id) => {
+        // invite_ notifications are Firestore-only, not in the API
+        if (id.startsWith("invite_")) {
+            setNotifications(prev =>
+                prev.map(n => (n.id === id ? { ...n, read: true } : n))
+            );
+            setUnreadCount(prev => Math.max(0, prev - 1));
+            return;
+        }
         try {
             const res = await fetch(`/api/notifications/${id}`, {
                 method: "PATCH",
@@ -71,6 +121,15 @@ export function NotificationProvider({ children }) {
     };
 
     const deleteNotification = async (id) => {
+        // invite_ notifications: just remove from local state (don't call API)
+        if (id.startsWith("invite_")) {
+            const deleted = notifications.find(n => n.id === id);
+            setNotifications(prev => prev.filter(n => n.id !== id));
+            if (deleted && !deleted.read) {
+                setUnreadCount(prev => Math.max(0, prev - 1));
+            }
+            return;
+        }
         try {
             const res = await fetch(`/api/notifications/${id}`, { method: "DELETE" });
             if (res.ok) {


### PR DESCRIPTION
## Which issue does this PR close?
Closes #386

## Rationale for this change
InnoVision currently focuses on individual learning. Peer-to-peer learning significantly improves engagement, motivation, and knowledge retention. This PR adds a collaborative study room feature so learners can study, discuss doubts, and learn together in real time.

## What changes are included in this PR?

### New files
- `src/app/study-rooms/page.jsx` — Main study rooms page with room sidebar, chat area, create room modal, and invite accept/decline banner
- `src/app/api/rooms/create/route.js` — API route to create a new study room
- `src/app/api/rooms/invite/route.js` — API route to invite a user by username
- `src/app/api/rooms/join/route.js` — API route to accept an invite and join a room
- `src/components/study-rooms/RoomList.jsx` — Real-time sidebar list of rooms the user belongs to
- `src/components/study-rooms/ChatWindow.jsx` — Real-time chat inside a room using Firebase onSnapshot
- `src/components/study-rooms/InviteModal.jsx` — Modal to invite a friend by username with helpful hint about username format

### Modified files
- `src/contexts/auth.js` — Added `username` field (email prefix) when saving new users to Firestore
- `src/contexts/notifications.js` — Added real-time Firestore listener for pending invitations so they appear in the existing notification bell instantly
- `src/components/Navbar/Navbar.jsx` — Added Study Rooms icon (Users) to the navigation bar

### Feature flow
1. User creates a study room via the + button in the sidebar
2. User invites a friend by typing their username (the part before @gmail.com in their email)
3. Invited user sees a notification in the bell icon immediately (real-time)
4. Clicking the notification opens `/study-rooms?invite=ID` where an Accept & Join / Decline banner appears
5. On accepting, the user is added to the room and the chat opens automatically
6. All chat messages update in real time using Firebase onSnapshot

## Are these changes tested?
Manually tested the following:
- Creating a room
- Inviting a user by username (valid and invalid usernames)
- Receiving invite notification in real time on the invited user's screen
- Accepting the invite and being automatically added to the room chat
- Declining the invite
- Real-time chat messages between two users in the same room
- XP awarded (15 XP) on first message sent in a room
- Study Rooms icon visible and active in navbar on desktop and mobile

No automated tests included as the feature relies heavily on Firebase real-time listeners and UI interactions. Existing tests are not affected.

## Are there any user-facing changes?
Yes:
- New `/study-rooms` page accessible from the navbar (Users icon)
- New notification type in the bell for study room invites
- Existing users will need a `username` field added to their Firestore user document manually (value = part of email before @). New sign-ups get this automatically.
- `firestore.rules` not included in this PR — the following rules need to be added to the project's Firestore rules by a maintainer:


<img width="1505" height="823" alt="Screenshot 2026-06-05 071253" src="https://github.com/user-attachments/assets/cbc48461-d22a-44d3-88c2-37d7106ecb8b" />

<img width="1533" height="940" alt="Screenshot 2026-06-05 070750" src="https://github.com/user-attachments/assets/eae0373e-2c07-4596-a822-6b3d3640b984" />

<img width="1535" height="905" alt="Screenshot 2026-06-05 070803" src="https://github.com/user-attachments/assets/c545cb00-199e-4021-97da-02614ca1fc15" />

<img width="1526" height="971" alt="Screenshot 2026-06-05 071147" src="https://github.com/user-attachments/assets/82e03158-f770-4e69-83a1-0c13913bfcc2" />

<img width="1536" height="976" alt="Screenshot 2026-06-05 070653" src="https://github.com/user-attachments/assets/32971cfb-631f-49ce-8721-ea398a01d462" />




