### PR TITLE
fix: remove debug console.log statements from API routes

### DIFF
--- a/src/app/api/content/ingest/route.js
+++ b/src/app/api/content/ingest/route.js
@@ -17,10 +17,8 @@ export async function POST(request) {
         userId = decoded.email || decoded.uid;
       }
     } catch (authError) {
-      console.log("[DEBUG] Auth verification failed, using anonymous:", authError.message);
+      // Auth failed, continue as anonymous
     }
-
-    console.log("[DEBUG] Content ingestion userId:", userId);
 
     const formData = await request.formData();
     const file = formData.get("file");
@@ -49,7 +47,6 @@ export async function POST(request) {
 
     if (userId && userId !== "anonymous") {
       const adminDb = getAdminDb();
-      console.log("[DEBUG] Creating ingestion notification with link:", `/ingested-course/${result.courseId}`);
       createNotification(adminDb, {
         userId,
         title: "Course Created from File!",

--- a/src/app/api/ingested-courses/[courseId]/route.js
+++ b/src/app/api/ingested-courses/[courseId]/route.js
@@ -73,7 +73,7 @@ export async function GET(request, { params }) {
                 }
             }
         } catch (err) {
-            console.log("[DEBUG] Auth check failed in course detail API:", err.message);
+            // Auth check failed, continue without userId
         }
 
         // Fetch progress if userId is available


### PR DESCRIPTION
Remove leftover [DEBUG] console.log statements from:
- src/app/api/content/ingest/route.js
- src/app/api/ingested-courses/[courseId]/route.js

These debug statements should not be in production code.

## Which issue does this PR close?

<!--
We generally require a GitHub issue to be filed for all bug fixes and enhancements and this helps us generate change logs for our releases. You can link an issue to this PR using the GitHub syntax. For example `Closes #123` indicates that this PR will close issue #123.
-->

- Closes #.

## Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

## What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

## Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

## Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
