### PR TITLE
docs(contributing): fix repository name in clone commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,8 +89,8 @@ We welcome feature suggestions! Please create an issue with:
 
 2. **Clone your fork**
    ```bash
-   git clone https://github.com/YOUR_USERNAME/Innovision-Open-Source.git
-   cd Innovision-Open-Source
+   git clone https://github.com/YOUR_USERNAME/Innovision-AI-Courses.git
+   cd Innovision-AI-Courses
    ```
 
 3. **Create a new branch**


### PR DESCRIPTION
## Description
Fixed the repository name in CONTRIBUTING.md from `Innovision-Open-Source` to `Innovision-AI-Courses` for accurate cloning instructions. This ensures new contributors clone the correct repository when following the contribution guidelines.

## Type of Change
- [ ] Bug fix
- [x] Documentation update
- [ ] New feature
- [ ] Breaking change

## Related Issues
Improves documentation accuracy for new contributors following the setup instructions.

## Changes Made
- Updated `git clone` command on line 92 from `Innovision-Open-Source` to `Innovision-AI-Courses`
- Updated `cd` command on line 93 to match the correct repository name for better path 

## Screenshots (if applicable)
N/A - Documentation only

## Testing
Verified that the updated commands now reference the correct repository name:
- `https://github.com/YOUR_USERNAME/Innovision-AI-Courses.git`
- `cd Innovision-AI-Courses`

## Checklist
- [x] Code follows style guidelines
- [x] Self-reviewed the code
- [x] Commented complex code (if needed)
- [x] Updated documentation
- [x] No new warnings generated
- [x] Tested on repository (verified URLs are correct)